### PR TITLE
[TK-1320, TK-1357] Add basic workspace attributes

### DIFF
--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -47,7 +47,7 @@ type WorkspaceSpec struct {
 	// The directory where Terraform will execute, specified as a relative path from the root of the configuration directory.
 	// More information: https://www.terraform.io/cloud-docs/workspaces/settings#terraform-working-directory
 	//+optional
-	TerraformWorkingDirectory string `json:"terraformWorkingDirectory,omitempty"`
+	WorkingDirectory string `json:"workingDirectory,omitempty"`
 }
 
 // WorkspaceStatus defines the observed state of Workspace

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -69,11 +69,6 @@ spec:
                   information: https://www.terraform.io/cloud-docs/workspaces/settings#terraform-version'
                 pattern: ^\d{1}\.\d{1,2}\.\d{1,2}$
                 type: string
-              terraformWorkingDirectory:
-                description: 'The directory where Terraform will execute, specified
-                  as a relative path from the root of the configuration directory.
-                  More information: https://www.terraform.io/cloud-docs/workspaces/settings#terraform-working-directory'
-                type: string
               token:
                 description: 'API Token to be used for API calls More information:
                   https://www.terraform.io/cloud-docs/users-teams-organizations/api-tokens'
@@ -99,6 +94,11 @@ spec:
                 required:
                 - secretKeyRef
                 type: object
+              workingDirectory:
+                description: 'The directory where Terraform will execute, specified
+                  as a relative path from the root of the configuration directory.
+                  More information: https://www.terraform.io/cloud-docs/workspaces/settings#terraform-working-directory'
+                type: string
             required:
             - name
             - organization
@@ -107,24 +107,10 @@ spec:
           status:
             description: WorkspaceStatus defines the observed state of Workspace
             properties:
-              applyMethod:
-                description: Define either change will be applied automatically(auto)
-                  or require an operator to confirm(manual).
-                type: string
-              executionMode:
-                description: Define where the Terraform code will be executed.
-                type: string
               observedGeneration:
                 description: Real world state generation
                 format: int64
                 type: integer
-              terraformVersion:
-                description: The version of Terraform to use for this workspace.
-                type: string
-              terraformWorkingDirectory:
-                description: The directory where Terraform will execute, specified
-                  as a relative path from the root of the configuration directory.
-                type: string
               updateAt:
                 description: Workspace last update timestamp
                 format: int64
@@ -133,11 +119,7 @@ spec:
                 description: Workspace ID that is managed by the controller
                 type: string
             required:
-            - applyMethod
-            - executionMode
             - observedGeneration
-            - terraformVersion
-            - terraformWorkingDirectory
             - updateAt
             - workspaceID
             type: object

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -219,7 +219,7 @@ func (r *WorkspaceReconciler) createWorkspace(ctx context.Context, instance *app
 		Description:      tfc.String(spec.Description),
 		ExecutionMode:    tfc.String(spec.ExecutionMode),
 		TerraformVersion: tfc.String(spec.TerraformVersion),
-		WorkingDirectory: tfc.String(spec.TerraformWorkingDirectory),
+		WorkingDirectory: tfc.String(spec.WorkingDirectory),
 	}
 
 	workspace, err := r.tfClient.Client.Workspaces.Create(ctx, spec.Organization, options)
@@ -259,8 +259,8 @@ func (r *WorkspaceReconciler) updateWorkspace(ctx context.Context, instance *app
 	if workspace.TerraformVersion != spec.TerraformVersion {
 		updateOptions.TerraformVersion = tfc.String(spec.TerraformVersion)
 	}
-	if workspace.WorkingDirectory != spec.TerraformWorkingDirectory {
-		updateOptions.WorkingDirectory = tfc.String(spec.TerraformWorkingDirectory)
+	if workspace.WorkingDirectory != spec.WorkingDirectory {
+		updateOptions.WorkingDirectory = tfc.String(spec.WorkingDirectory)
 	}
 
 	return r.tfClient.Client.Workspaces.UpdateByID(ctx, instance.Status.WorkspaceID, updateOptions)

--- a/controllers/workspace_controller_test.go
+++ b/controllers/workspace_controller_test.go
@@ -79,12 +79,12 @@ var _ = Describe("Workspace controller", Ordered, func() {
 						Key: secretKey,
 					},
 				},
-				Name:                      workspace,
-				ApplyMethod:               "auto",
-				Description:               "Description",
-				ExecutionMode:             "remote",
-				TerraformVersion:          "1.2.3",
-				TerraformWorkingDirectory: "aws/us-west-1/vpc",
+				Name:             workspace,
+				ApplyMethod:      "auto",
+				Description:      "Description",
+				ExecutionMode:    "remote",
+				TerraformVersion: "1.2.3",
+				WorkingDirectory: "aws/us-west-1/vpc",
 			},
 			Status: appv1alpha2.WorkspaceStatus{},
 		}
@@ -166,7 +166,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			instance.Spec.Description = fmt.Sprintf("%v-new", instance.Spec.Description)
 			instance.Spec.ExecutionMode = "local"
 			instance.Spec.TerraformVersion = "1.2.1"
-			instance.Spec.TerraformWorkingDirectory = fmt.Sprintf("%v/new", instance.Spec.TerraformWorkingDirectory)
+			instance.Spec.WorkingDirectory = fmt.Sprintf("%v/new", instance.Spec.WorkingDirectory)
 			Expect(k8sClient.Update(ctx, instance)).Should(Succeed())
 
 			// Wait until the controller updates Terraform Cloud workspace
@@ -178,7 +178,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 					ws.Description == instance.Spec.Description &&
 					ws.ExecutionMode == instance.Spec.ExecutionMode &&
 					ws.TerraformVersion == instance.Spec.TerraformVersion &&
-					ws.WorkingDirectory == instance.Spec.TerraformWorkingDirectory
+					ws.WorkingDirectory == instance.Spec.WorkingDirectory
 			}).Should(BeTrue())
 
 			// Delete the Kubernetes workspace object and wait until the controller finishes the reconciliation after deletion of the object


### PR DESCRIPTION
### Description

This PR adds the following basic workspace attributes to both `spec` and `status`(except `description`) for better observability:
- [Apply Method](https://www.terraform.io/cloud-docs/workspaces/settings#auto-apply-and-manual-apply)
- Description
- [Execution Mode](https://www.terraform.io/cloud-docs/workspaces/settings#execution-mode)
- [Terraform Version](https://www.terraform.io/cloud-docs/workspaces/settings#terraform-version)
- [Terraform Working Directory](https://www.terraform.io/cloud-docs/workspaces/settings#terraform-working-directory)

In addition to that:
- Updates field descriptions in CRD and adds links to documentation
- Adds pattern check to `spec.name`

### Usage Example
```yaml
---
apiVersion: app.terraform.io/v1alpha2
kind: Workspace
metadata:
  name: this
spec:
  organization: hashicorp
  token:
    secretKeyRef:
      name: terraform-cloud
      key: token
  name: kubernetes-operator
  ### NEW ###
  applyMethod: auto
  description: Workspace Description
  executionMode: remote
  terraformVersion: 1.2.3
  terraformWorkingDirectory: dev/
```