### PR TITLE
[TK-1872] Add support for allow destroy plan

### DIFF
--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -212,6 +212,12 @@ type WorkspaceSpec struct {
 	//+kubebuilder:default=manual
 	//+optional
 	ApplyMethod string `json:"applyMethod,omitempty"`
+	// Allows a destroy plan to be created and applied.
+	// More information:
+	//  - https://www.terraform.io/cloud-docs/workspaces/settings#destruction-and-deletion
+	//+kubebuilder:default=true
+	//+optional
+	AllowDestroyPlan bool `json:"allowDestroyPlan,omitempty"`
 	// Workspace description
 	//+optional
 	Description string `json:"description,omitempty"`

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -52,6 +52,11 @@ spec:
                     description: Agent Pool name.
                     type: string
                 type: object
+              allowDestroyPlan:
+                default: true
+                description: 'Allows a destroy plan to be created and applied. More
+                  information: - https://www.terraform.io/cloud-docs/workspaces/settings#destruction-and-deletion'
+                type: boolean
               applyMethod:
                 default: manual
                 description: 'Define either change will be applied automatically(auto)

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -254,6 +254,7 @@ func (r *WorkspaceReconciler) createWorkspace(ctx context.Context, instance *app
 	spec := instance.Spec
 	options := tfc.WorkspaceCreateOptions{
 		Name:             tfc.String(spec.Name),
+		AllowDestroyPlan: tfc.Bool(spec.AllowDestroyPlan),
 		AutoApply:        tfc.Bool(applyMethodToBool(spec.ApplyMethod)),
 		Description:      tfc.String(spec.Description),
 		ExecutionMode:    tfc.String(spec.ExecutionMode),
@@ -333,6 +334,10 @@ func (r *WorkspaceReconciler) updateWorkspace(ctx context.Context, instance *app
 
 	if workspace.AutoApply != applyMethodToBool(spec.ApplyMethod) {
 		updateOptions.AutoApply = tfc.Bool(applyMethodToBool(spec.ApplyMethod))
+	}
+
+	if workspace.AllowDestroyPlan != spec.AllowDestroyPlan {
+		updateOptions.AllowDestroyPlan = tfc.Bool(spec.AllowDestroyPlan)
 	}
 
 	if workspace.Description != spec.Description {

--- a/controllers/workspace_controller_test.go
+++ b/controllers/workspace_controller_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 				},
 				Name:             workspace,
 				ApplyMethod:      "auto",
+				AllowDestroyPlan: true,
 				Description:      "Description",
 				ExecutionMode:    "remote",
 				TerraformVersion: "1.2.3",
@@ -123,6 +124,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 
 			// Update the Kubernetes workspace object fields(basic workspace attributes)
 			instance.Spec.ApplyMethod = "manual"
+			instance.Spec.AllowDestroyPlan = false
 			instance.Spec.Description = fmt.Sprintf("%v-new", instance.Spec.Description)
 			instance.Spec.ExecutionMode = "local"
 			instance.Spec.TerraformVersion = "1.2.1"
@@ -135,6 +137,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 				Expect(ws).ShouldNot(BeNil())
 				Expect(err).Should(Succeed())
 				return ws.AutoApply == applyMethodToBool(instance.Spec.ApplyMethod) &&
+					ws.AllowDestroyPlan == instance.Spec.AllowDestroyPlan &&
 					ws.Description == instance.Spec.Description &&
 					ws.ExecutionMode == instance.Spec.ExecutionMode &&
 					ws.TerraformVersion == instance.Spec.TerraformVersion &&


### PR DESCRIPTION
### Description

This PR adds support for the Workspace option `Allow Destroy Plan`.

More details: https://www.terraform.io/cloud-docs/workspaces/settings#destruction-and-deletion

### Usage Example
```yaml
---
apiVersion: app.terraform.io/v1alpha2
kind: Workspace
metadata:
  name: this
spec:
  organization: hashicorp
  token:
    secretKeyRef:
      name: terraform-cloud
      key: token
  name: kubernetes-operator
### NEW ###
  allowDestroyPlan: false
      
```