### PR TITLE
Fix the concurrency issue of the Workspace controller

### DIFF
--- a/api/v1alpha2/workspace_helpers.go
+++ b/api/v1alpha2/workspace_helpers.go
@@ -1,0 +1,17 @@
+package v1alpha2
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (w *Workspace) NeedToAddFinalizer(finalizer string) bool {
+	return w.ObjectMeta.DeletionTimestamp.IsZero() && !controllerutil.ContainsFinalizer(w, finalizer)
+}
+
+func (w *Workspace) IsDeletionCandidate(finalizer string) bool {
+	return !w.ObjectMeta.DeletionTimestamp.IsZero() && controllerutil.ContainsFinalizer(w, finalizer)
+}
+
+func (w *Workspace) IsCreationCandidate() bool {
+	return w.Status.WorkspaceID == ""
+}

--- a/controllers/workspace_controller_agents.go
+++ b/controllers/workspace_controller_agents.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	appv1alpha2 "github.com/hashicorp/terraform-cloud-operator/api/v1alpha2"
-
 	tfc "github.com/hashicorp/go-tfe"
 )
 
-func (r *WorkspaceReconciler) getAgentPoolIDByName(ctx context.Context, instance *appv1alpha2.Workspace) (string, error) {
-	agentPoolName := instance.Spec.AgentPool.Name
+func (r *WorkspaceReconciler) getAgentPoolIDByName(ctx context.Context, w *workspaceInstance) (string, error) {
+	agentPoolName := w.instance.Spec.AgentPool.Name
 
-	agentPoolIDs, err := r.tfClient.Client.AgentPools.List(ctx, instance.Spec.Organization, &tfc.AgentPoolListOptions{
+	agentPoolIDs, err := w.tfClient.Client.AgentPools.List(ctx, w.instance.Spec.Organization, &tfc.AgentPoolListOptions{
 		Query: agentPoolName,
 	})
 	if err != nil {
@@ -28,14 +26,14 @@ func (r *WorkspaceReconciler) getAgentPoolIDByName(ctx context.Context, instance
 	return "", fmt.Errorf("agent pool ID not found for agent pool name %q", agentPoolName)
 }
 
-func (r *WorkspaceReconciler) getAgentPoolID(ctx context.Context, instance *appv1alpha2.Workspace) (string, error) {
-	specAgentPool := instance.Spec.AgentPool
+func (r *WorkspaceReconciler) getAgentPoolID(ctx context.Context, w *workspaceInstance) (string, error) {
+	specAgentPool := w.instance.Spec.AgentPool
 
 	if specAgentPool.Name != "" {
-		r.log.Info("Reconcile Agent Pool", "msg", "getting agent pool ID by name")
-		return r.getAgentPoolIDByName(ctx, instance)
+		w.log.Info("Reconcile Agent Pool", "msg", "getting agent pool ID by name")
+		return r.getAgentPoolIDByName(ctx, w)
 	}
 
-	r.log.Info("Reconcile Agent Pool", "msg", "getting agent pool ID from the spec.AgentPool.ID")
+	w.log.Info("Reconcile Agent Pool", "msg", "getting agent pool ID from the spec.AgentPool.ID")
 	return specAgentPool.ID, nil
 }

--- a/controllers/workspace_controller_tags.go
+++ b/controllers/workspace_controller_tags.go
@@ -66,33 +66,33 @@ func tagDifference(leftTags, rightTags map[string]bool) []*tfc.Tag {
 }
 
 // addWorkspaceTags adds tags to workspace
-func (r *WorkspaceReconciler) addWorkspaceTags(ctx context.Context, instance *appv1alpha2.Workspace, tags []*tfc.Tag) error {
+func (r *WorkspaceReconciler) addWorkspaceTags(ctx context.Context, w *workspaceInstance, tags []*tfc.Tag) error {
 	if len(tags) == 0 {
 		return nil
 	}
 
-	return r.tfClient.Client.Workspaces.AddTags(ctx, instance.Status.WorkspaceID, tfc.WorkspaceAddTagsOptions{Tags: tags})
+	return w.tfClient.Client.Workspaces.AddTags(ctx, w.instance.Status.WorkspaceID, tfc.WorkspaceAddTagsOptions{Tags: tags})
 }
 
 // removeWorkspaceTags removes tags from workspace
-func (r *WorkspaceReconciler) removeWorkspaceTags(ctx context.Context, instance *appv1alpha2.Workspace, tags []*tfc.Tag) error {
+func (r *WorkspaceReconciler) removeWorkspaceTags(ctx context.Context, w *workspaceInstance, tags []*tfc.Tag) error {
 	if len(tags) == 0 {
 		return nil
 	}
 
-	return r.tfClient.Client.Workspaces.RemoveTags(ctx, instance.Status.WorkspaceID, tfc.WorkspaceRemoveTagsOptions{Tags: tags})
+	return w.tfClient.Client.Workspaces.RemoveTags(ctx, w.instance.Status.WorkspaceID, tfc.WorkspaceRemoveTagsOptions{Tags: tags})
 }
 
-func (r *WorkspaceReconciler) reconcileTags(ctx context.Context, instance *appv1alpha2.Workspace, workspace *tfc.Workspace) error {
-	r.log.Info("Reconcile Tags", "msg", "new reconciliation event")
+func (r *WorkspaceReconciler) reconcileTags(ctx context.Context, w *workspaceInstance, workspace *tfc.Workspace) error {
+	w.log.Info("Reconcile Tags", "msg", "new reconciliation event")
 
-	instanceTags := getTags(instance)
+	instanceTags := getTags(&w.instance)
 	workspaceTags := getWorkspaceTags(workspace)
 
 	removeTags := getTagsToRemove(instanceTags, workspaceTags)
 	if len(removeTags) > 0 {
-		r.log.Info("Reconcile Tags", "msg", "removing tags from the workspace")
-		err := r.removeWorkspaceTags(ctx, instance, removeTags)
+		w.log.Info("Reconcile Tags", "msg", "removing tags from the workspace")
+		err := r.removeWorkspaceTags(ctx, w, removeTags)
 		if err != nil {
 			return err
 		}
@@ -100,8 +100,8 @@ func (r *WorkspaceReconciler) reconcileTags(ctx context.Context, instance *appv1
 
 	addTags := getTagsToAdd(instanceTags, workspaceTags)
 	if len(addTags) > 0 {
-		r.log.Info("Reconcile Tags", "msg", "adding tags from the workspace")
-		err := r.addWorkspaceTags(ctx, instance, addTags)
+		w.log.Info("Reconcile Tags", "msg", "adding tags from the workspace")
+		err := r.addWorkspaceTags(ctx, w, addTags)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

This PR fixes a potential bug when multiple Workspace workers run concurrently. Since logging and TFC Client are parts of the `WorkspaceReconciler` structure it becomes mutable and shared between Workspace workers. That leads to the situation when the latest reconciliation event overwrites logging and TFC client for all workers that are running concurrently. In that case, logging is not more accurate and displays messages for the same objects altho the real messages belong to different objects. The same happens with the TFC client, it may end up in a situation where a reconciliation event cannot be finished correctly if the workspace it is working on belongs to a different team or organization that the one from the latest reconciliation event. Also, in rare cases, a workspace can be created in the wrong organization and it won't be possible to reconcile it in the future.

This PR separates instance-specific objects from the `WorkspaceReconciler` structure to its own structure `workspaceInstance` that is unique per reconciliation event and the above issue is not valid anymore.

Additionally, moved helper functions to a separate file and made their methods of the `instanceWorkspace` structure. This change is done for the sake of consistency with the `Module` code.

### Usage Example
Nothing has changed externally.