### PR TITLE
Add community health files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,5 @@
+# Code of Conduct
+
+HashiCorp Community Guidelines apply to you when interacting with the community here on GitHub and contributing code.
+
+Please read the full text at https://www.hashicorp.com/community-guidelines

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,11 @@
+We deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
+
+If you would like to report a vulnerability in one of our products, or have security concerns regarding HashiCorp software, please email [security@hashicorp.com](mailto:security@hashicorp.com).
+
+In order for us to best respond to your report, please include any of the following:
+
+* Steps to reproduce or proof-of-concept
+* Any relevant tools, including versions used
+* Tool output
+
+For additional information about HashiCorp security, please see [https://hashicorp.com/security](https://hashicorp.com/security).

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) 2022 HashiCorp, Inc.
+
 Mozilla Public License Version 2.0
 ==================================
 


### PR DESCRIPTION
### Description

This PR adds mandatory community health files and HashiCorp copyright to the LICENSE file.

### Usage Example
Nothing has changed externally.