### PR TITLE
🐛 [TK-2026] Fix race condition in `Workspace` and `Module` outputs

### DIFF
--- a/controllers/module_controller.go
+++ b/controllers/module_controller.go
@@ -170,11 +170,8 @@ func (r *ModuleReconciler) updateStatusRun(ctx context.Context, instance *appv1a
 	return r.Status().Update(ctx, instance)
 }
 
-func (r *ModuleReconciler) updateStatusOutputs(ctx context.Context, instance *appv1alpha2.Module, workspace *tfc.Workspace, runID string) error {
+func (r *ModuleReconciler) updateStatusOutputs(ctx context.Context, instance *appv1alpha2.Module, workspace *tfc.Workspace) error {
 	instance.Status.WorkspaceID = workspace.ID
-	instance.Status.Output = &appv1alpha2.OutputStatus{
-		RunID: runID,
-	}
 
 	return r.Status().Update(ctx, instance)
 }
@@ -492,7 +489,7 @@ func (r *ModuleReconciler) reconcileModule(ctx context.Context, m *moduleInstanc
 	}
 
 	// Reconcile Outputs
-	runID, err := r.reconcileOutputs(ctx, m, workspace)
+	err = r.reconcileOutputs(ctx, m, workspace)
 	if err != nil {
 		m.log.Error(err, "Reconcile Module Outputs", "msg", "failed to reconcile outputs")
 		r.Recorder.Event(&m.instance, corev1.EventTypeWarning, "ReconcileModuleOutputs", "Failed to reconcile outputs")
@@ -500,9 +497,6 @@ func (r *ModuleReconciler) reconcileModule(ctx context.Context, m *moduleInstanc
 	}
 	m.log.Info("Reconcile Module Outputs", "msg", "successfully reconcilied outputs")
 	r.Recorder.Event(&m.instance, corev1.EventTypeNormal, "ReconcileModuleOutputs", "Successfully reconcilied outputs")
-	if runID == "" {
-		return nil
-	}
 
-	return r.updateStatusOutputs(ctx, &m.instance, workspace, runID)
+	return r.updateStatusOutputs(ctx, &m.instance, workspace)
 }

--- a/controllers/module_controller_test.go
+++ b/controllers/module_controller_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 
 	BeforeAll(func() {
 		// Set default Eventually timers
-		SetDefaultEventuallyTimeout(120 * time.Second)
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 	})
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -84,7 +84,7 @@ var _ = BeforeSuite(func() {
 	//+kubebuilder:scaffold:scheme
 
 	if organization == "" {
-		Fail("Environment variable TFC_ORG is either not set or empty but required")
+		Fail("Environment variable TFC_ORG is required, but either not set or empty")
 	}
 	if terraformToken == "" {
 		Fail("Environment variable TFC_TOKEN is either not set or empty but required")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -87,7 +87,7 @@ var _ = BeforeSuite(func() {
 		Fail("Environment variable TFC_ORG is required, but either not set or empty")
 	}
 	if terraformToken == "" {
-		Fail("Environment variable TFC_TOKEN is either not set or empty but required")
+		Fail("Environment variable TFC_TOKEN is required, but either not set or empty")
 	}
 	// Terraform Cloud Client
 	tfClient, err = tfc.NewClient(&tfc.Config{Token: os.Getenv("TFC_TOKEN")})

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -38,6 +39,8 @@ var tfClient *tfc.Client
 
 var organization = os.Getenv("TFC_ORG")
 var terraformToken = os.Getenv("TFC_TOKEN")
+
+var syncPeriod = 30 * time.Second
 
 var secretKey = "token"
 var namespacedName = types.NamespacedName{
@@ -80,6 +83,12 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 
+	if organization == "" {
+		Fail("Environment variable TFC_ORG is either not set or empty but required")
+	}
+	if terraformToken == "" {
+		Fail("Environment variable TFC_TOKEN is either not set or empty but required")
+	}
 	// Terraform Cloud Client
 	tfClient, err = tfc.NewClient(&tfc.Config{Token: os.Getenv("TFC_TOKEN")})
 	Expect(err).Should(Succeed())
@@ -91,10 +100,15 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).ToNot(BeNil())
 
 	// Kubernetes Manager
-	syncPeriod := 30 * time.Second
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:     scheme.Scheme,
 		SyncPeriod: &syncPeriod,
+		Controller: v1alpha1.ControllerConfigurationSpec{
+			GroupKindConcurrency: map[string]int{
+				"Workspace.app.terraform.io": 5,
+				"Module.app.terraform.io":    5,
+			},
+		},
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -226,9 +226,6 @@ func (r *WorkspaceReconciler) updateStatus(ctx context.Context, w *workspaceInst
 			return err
 		}
 		w.instance.Status.Run.Status = string(run.Status)
-		if run.Status == tfc.RunApplied {
-			w.instance.Status.Run.OutputRunID = workspace.CurrentRun.ID
-		}
 	}
 
 	return r.Status().Update(ctx, &w.instance)

--- a/controllers/workspace_controller_agents_test.go
+++ b/controllers/workspace_controller_agents_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 
 	BeforeAll(func() {
 		// Set default Eventually timers
-		SetDefaultEventuallyTimeout(90 * time.Second)
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 		// Create an Agent Pools

--- a/controllers/workspace_controller_remote_state_sharing_test.go
+++ b/controllers/workspace_controller_remote_state_sharing_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 
 	BeforeAll(func() {
 		// Set default Eventually timers
-		SetDefaultEventuallyTimeout(90 * time.Second)
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 		// Create new workspaces for tests

--- a/controllers/workspace_controller_run_triggers_test.go
+++ b/controllers/workspace_controller_run_triggers_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 
 	BeforeAll(func() {
 		// Set default Eventually timers
-		SetDefaultEventuallyTimeout(90 * time.Second)
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 		// Create two new workspaces to act as a source for Run Triggers

--- a/controllers/workspace_controller_sshkey_test.go
+++ b/controllers/workspace_controller_sshkey_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 
 	BeforeAll(func() {
 		// Set default Eventually timers
-		SetDefaultEventuallyTimeout(90 * time.Second)
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 		// Create an SSH keys

--- a/controllers/workspace_controller_team_access_test.go
+++ b/controllers/workspace_controller_team_access_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 
 	BeforeAll(func() {
 		// Set default Eventually timers
-		SetDefaultEventuallyTimeout(90 * time.Second)
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 		// Create new teams

--- a/controllers/workspace_controller_test.go
+++ b/controllers/workspace_controller_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 
 	BeforeAll(func() {
 		// Set default Eventually timers
-		SetDefaultEventuallyTimeout(90 * time.Second)
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 	})
 

--- a/controllers/workspace_controller_variables_test.go
+++ b/controllers/workspace_controller_variables_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 
 	BeforeAll(func() {
 		// Set default Eventually timers
-		SetDefaultEventuallyTimeout(90 * time.Second)
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 
 		// Create a secret object that will be used by the controller to get variables

--- a/controllers/workspace_controller_vcs_test.go
+++ b/controllers/workspace_controller_vcs_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			Skip("Environment variable TFC_VCS_REPO is either not set or empty")
 		}
 		// Set default Eventually timers
-		SetDefaultEventuallyTimeout(90 * time.Second)
+		SetDefaultEventuallyTimeout(syncPeriod * 4)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
 	})
 


### PR DESCRIPTION
### Description

This PR addresses intermittent race condition issues in the `Workspace` and `Module` controllers when they create or update outputs. The issue happens when the ongoing Run is finished while the operator is reconciling `Workspace` or `Module`. In this case, method `reconcileOutputs` has outdated information about `CurrentStateVersion` and either does not create related `ConfigMap` or `Secret` or does not update them with the recent changes. If that happens, the outputs will remain outdated until the next Run happens.

This PR adds an additional API call to get an updated TFC Workspace item when `Run` finishes between the time when a new reconciliation starts and synchronizes outputs. The method `reconcileOutputs` now is the one responsible for updating the `Status` of the relevant Kubernetes object.