### PR TITLE
[TK-2027] 📖 Add API reference documentation generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,15 @@ all: build
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+##@ Documentation
+.PHONY: docs
+docs: crd-ref-docs ## Generate API reference documentation.
+	$(CRD_REF_DOCS) --renderer=markdown --source-path ./api/v1alpha2/ --config=./docs/config.yaml --output-path ./docs/api-reference.md
+
 ##@ Development
 
 .PHONY: manifests
-manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
+manifests: controller-gen docs## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 .PHONY: generate
@@ -158,10 +163,17 @@ $(LOCALBIN):
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 
 ## Tool Versions
+<<<<<<< HEAD
 KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.10.0
+=======
+KUSTOMIZE_VERSION ?= v4.5.5
+CONTROLLER_TOOLS_VERSION ?= v0.9.0
+CRD_REF_DOCS_VERSION ?= v0.0.8
+>>>>>>> 68ea1d2 (Add API reference documentation auto-generation)
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -178,6 +190,11 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+.PHONY: crd-ref-docs
+crd-ref-docs: $(CRD_REF_DOCS) ## Download crd-ref-docs locally if necessary.
+$(CRD_REF_DOCS): $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VERSION)
 
 .PHONY: bundle
 bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.

--- a/Makefile
+++ b/Makefile
@@ -166,14 +166,9 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 
 ## Tool Versions
-<<<<<<< HEAD
 KUSTOMIZE_VERSION ?= v4.5.7
 CONTROLLER_TOOLS_VERSION ?= v0.10.0
-=======
-KUSTOMIZE_VERSION ?= v4.5.5
-CONTROLLER_TOOLS_VERSION ?= v0.9.0
 CRD_REF_DOCS_VERSION ?= v0.0.8
->>>>>>> 68ea1d2 (Add API reference documentation auto-generation)
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/docs/config.yaml
+++ b/docs/config.yaml
@@ -1,0 +1,10 @@
+# Configuration file for CRD Reference Documentation Generator: https://github.com/elastic/crd-ref-docs
+processor:
+  ignoreTypes:
+    - "AgentPoolList$"
+    - "ModuleList$"
+    - "WorkspaceList$"
+  ignoreFields:
+    - "status$"
+render:
+  kubernetesVersion: 1.25


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

### Description
This PR adds a new target `docs` to Makefile to automatically manage API reference documentation for CRD. It uses [this](https://github.com/elastic/crd-ref-docs) project for that purpose. The new target is also a part of the `manifest` one. That guarantees that API reference documentation will be constantly updated together with changes in CRDs.

### Usage Example
```console
$ make docs
GOBIN=/home/user/terraform-cloud-operator/bin go install github.com/elastic/crd-ref-docs@v0.0.8
/home/user/terraform-cloud-operator/bin/crd-ref-docs --renderer=markdown --source-path ./api/v1alpha2/ --config=./docs/config.yaml --output-path ./docs/api-reference.md
2022-12-08T10:38:43.644+0100	INFO	crd-ref-docs	Loading configuration	{"path": "./docs/config.yaml"}
2022-12-08T10:38:43.644+0100	INFO	crd-ref-docs	Processing source directory	{"directory": "./api/v1alpha2/", "depth": 6}
2022-12-08T10:38:44.040+0100	INFO	crd-ref-docs	Rendering output	{"path": "./docs/api-reference.md"}
2022-12-08T10:38:44.043+0100	INFO	crd-ref-docs	CRD reference documentation generated
2022-12-08T10:38:44.043+0100	INFO	crd-ref-docs	Execution time: 399.023958ms

$ make manifest
/home/user/terraform-cloud-operator/bin/crd-ref-docs --renderer=markdown --source-path ./api/v1alpha2/ --config=./docs/config.yaml --output-path ./docs/api-reference.md
2022-12-08T10:39:39.004+0100	INFO	crd-ref-docs	Loading configuration	{"path": "./docs/config.yaml"}
2022-12-08T10:39:39.005+0100	INFO	crd-ref-docs	Processing source directory	{"directory": "./api/v1alpha2/", "depth": 6}
2022-12-08T10:39:39.438+0100	INFO	crd-ref-docs	Rendering output	{"path": "./docs/api-reference.md"}
2022-12-08T10:39:39.441+0100	INFO	crd-ref-docs	CRD reference documentation generated
2022-12-08T10:39:39.441+0100	INFO	crd-ref-docs	Execution time: 435.716292ms
/home/user/terraform-cloud-operator/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):
```release-note
[ENHANCEMENT] Add a new target `docs` to Makefile to automatically manage API reference documentation for CRD. The new target is also a part of the `manifest` one. In this case, API reference documentation will be created or updated automatically with changes in CRD.
```

### References
N/A

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
