### PR TITLE
🐛 Fix an issue when manually created agent tokens are not removed

### DIFF
--- a/controllers/agentpool_controller_tokens.go
+++ b/controllers/agentpool_controller_tokens.go
@@ -36,7 +36,7 @@ func getTokensToRemove(ctx context.Context, ap *agentPoolInstance) ([]string, er
 	}
 
 	for _, t := range ap.instance.Status.AgentTokens {
-		if !s[t.Name] {
+		if _, ok := s[t.Name]; !ok {
 			d = append(d, t.ID)
 		}
 	}
@@ -50,8 +50,8 @@ func getTokensToRemove(ctx context.Context, ap *agentPoolInstance) ([]string, er
 	if err != nil {
 		return nil, err
 	}
-	for t := range st {
-		if !agentPoolTokens[t] {
+	for t := range agentPoolTokens {
+		if _, ok := st[t]; !ok {
 			d = append(d, t)
 		}
 	}
@@ -69,7 +69,7 @@ func getTokensToCreate(ctx context.Context, ap *agentPoolInstance) (map[string]b
 	}
 
 	for _, t := range ap.instance.Status.AgentTokens {
-		if !at[t.ID] {
+		if _, ok := at[t.ID]; !ok {
 			removeTokenFromStatus(ap, t.ID)
 		}
 	}
@@ -81,7 +81,7 @@ func getTokensToCreate(ctx context.Context, ap *agentPoolInstance) (map[string]b
 	}
 
 	for _, t := range ap.instance.Spec.AgentTokens {
-		if !st[t.Name] {
+		if _, ok := st[t.Name]; !ok {
 			a[t.Name] = true
 		}
 	}


### PR DESCRIPTION
### Description

This PR fixes an issue when manually created agent tokens are not removed from Agent Pool during the reconciliation.

### Usage Example
N/A

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
`AgentPool`: fix an issue when manually created agent tokens are not removed from Agent Pool during the reconciliation.
```

### References
N/A

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
