### PR TITLE
🚀 Update the Helm chart notes

### DIFF
--- a/charts/terraform-cloud-operator/templates/NOTES.txt
+++ b/charts/terraform-cloud-operator/templates/NOTES.txt
@@ -6,10 +6,10 @@ Documentation:
 Your release is named {{ .Release.Name }}.
 
 To get the release status, run:
-  $ helm status {{ .Release.Name }}
+  $ helm --namespace {{ .Release.Namespace }} status {{ .Release.Name }}
 
 To get the release values, run:
-  $ helm get values {{ .Release.Name }}
+  $ helm --namespace {{ .Release.Namespace }} get values {{ .Release.Name }}
 
 To read this notes again, run:
-  $ helm get notes {{ .Release.Name }}
+  $ helm --namespace {{ .Release.Namespace }} get notes {{ .Release.Name }}


### PR DESCRIPTION
### Description

This PR updates the Helm chart notes to print out the namespace name in the status.

Now:
```text
NOTES:
Thank you for installing HashiCorp Terraform Cloud Operator!

Documentation:
 - https://github.com/hashicorp/terraform-cloud-operator

Your release is named beta.

To get the release status, run:
  $ helm --namespace tfc-operator-system status beta

To get the release values, run:
  $ helm --namespace tfc-operator-system get values beta

To read this notes again, run:
  $ helm --namespace tfc-operator-system get notes beta
```

Before:
```text
NOTES:
Thank you for installing HashiCorp Terraform Cloud Operator!

Documentation:
 - https://github.com/hashicorp/terraform-cloud-operator

Your release is named beta.

To get the release status, run:
  $ helm status beta

To get the release values, run:
  $ helm get values beta

To read this notes again, run:
  $ helm get notes beta
```

### Usage Example

N/A

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
helm-chart: add the namespace name to the chart status output.
```

### References

N/A

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
