### PR TITLE
🐛 Fix an issue when the Module cannot get Workspace by ID

### DIFF
--- a/controllers/module_controller_test.go
+++ b/controllers/module_controller_test.go
@@ -111,7 +111,7 @@ var _ = Describe("Module controller", Ordered, func() {
 			})
 			Expect(err).Should(Succeed())
 
-			instance.Spec.Workspace.Name = ws.Name
+			instance.Spec.Workspace = &appv1alpha2.ModuleWorkspace{Name: ws.Name}
 			// Create a new Module
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 
@@ -163,7 +163,7 @@ var _ = Describe("Module controller", Ordered, func() {
 			})
 			Expect(err).Should(Succeed())
 
-			instance.Spec.Workspace.ID = ws.ID
+			instance.Spec.Workspace = &appv1alpha2.ModuleWorkspace{ID: ws.ID}
 			// Create a new Module
 			Expect(k8sClient.Create(ctx, instance)).Should(Succeed())
 

--- a/controllers/module_controller_workspace.go
+++ b/controllers/module_controller_workspace.go
@@ -15,7 +15,7 @@ func (r *ModuleReconciler) getWorkspaceByName(ctx context.Context, m *moduleInst
 }
 
 func (r *ModuleReconciler) getWorkspaceByID(ctx context.Context, m *moduleInstance) (*tfc.Workspace, error) {
-	return m.tfClient.Client.Workspaces.Read(ctx, m.instance.Spec.Organization, m.instance.Spec.Workspace.ID)
+	return m.tfClient.Client.Workspaces.ReadByID(ctx, m.instance.Spec.Workspace.ID)
 }
 
 func (r *ModuleReconciler) getWorkspace(ctx context.Context, m *moduleInstance) (*tfc.Workspace, error) {


### PR DESCRIPTION
### Description

This PR fixes an issue when the Module CR fails if it refers to Workspace by ID and updates tests to catch this scenario.

### Usage Example

N/A.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
`Module`: Fix an issue when the Module CR fails if it refers to Workspace by ID.
```

### References

N/A.

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
