### PR TITLE
🤖 Bump up Golang version to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-cloud-operator
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.3


### PR DESCRIPTION
### Description

Bump up Golang version to 1.20. 🎉

### Usage Example

N/A.

### Release Note

```release-note
`Operator`: bump up Golang version to 1.20.
```

### References

- https://go.dev/blog/go1.20

### Community Note
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
