### PR TITLE
🤖 Add E2E workflow to run on TFE

### DIFF
--- a/.github/workflows/end-to-end-tfc.yaml
+++ b/.github/workflows/end-to-end-tfc.yaml
@@ -1,0 +1,34 @@
+name: E2E on Terraform Cloud
+
+on:
+  schedule:
+    - cron: '30 5 * * *'
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run end-to-end test suite
+        run: make test
+        env:
+          TFC_OAUTH_TOKEN: ${{ secrets.TFC_OAUTH_TOKEN }}
+          TFC_ORG: ${{ secrets.TFC_ORG }}
+          TFC_TOKEN: ${{ secrets.TFC_TOKEN }}
+          TFC_VCS_REPO: ${{ secrets.TFC_VCS_REPO }}

--- a/.github/workflows/end-to-end-tfe.yaml
+++ b/.github/workflows/end-to-end-tfe.yaml
@@ -1,4 +1,4 @@
-name: End-to-end tests
+name: E2E on Terraform Enterprise
 
 on:
   schedule:
@@ -28,7 +28,8 @@ jobs:
       - name: Run end-to-end test suite
         run: make test
         env:
-          TFC_OAUTH_TOKEN: ${{ secrets.TFC_OAUTH_TOKEN }}
-          TFC_ORG: ${{ secrets.TFC_ORG }}
-          TFC_TOKEN: ${{ secrets.TFC_TOKEN }}
-          TFC_VCS_REPO: ${{ secrets.TFC_VCS_REPO }}
+          TFC_OAUTH_TOKEN: ${{ secrets.TFE_OAUTH_TOKEN }}
+          TFC_ORG: ${{ secrets.TFE_ORG }}
+          TFC_TOKEN: ${{ secrets.TFE_TOKEN }}
+          TFC_VCS_REPO: ${{ secrets.TFE_VCS_REPO }}
+          TFE_ADDRESS: ${{ secrets.TFE_ADDRESS }}

--- a/controllers/module_controller_test.go
+++ b/controllers/module_controller_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Module controller", Ordered, func() {
 					},
 				},
 				Module: &appv1alpha2.ModuleSource{
-					Source:  fmt.Sprintf("app.terraform.io/%v/module-random/provider", organization),
+					Source:  fmt.Sprintf("%s/%v/module-random/provider", cloudEndpoint, organization),
 					Version: "0.0.4",
 				},
 				DestroyOnDeletion: true,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,6 +43,7 @@ var tfClient *tfc.Client
 
 var organization = os.Getenv("TFC_ORG")
 var terraformToken = os.Getenv("TFC_TOKEN")
+var cloudEndpoint = "app.terraform.io"
 
 var syncPeriod = 30 * time.Second
 
@@ -65,6 +67,15 @@ func TestControllersAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("Set up endpoint")
+	if v, ok := os.LookupEnv("TFE_ADDRESS"); ok {
+		u, err := url.Parse(v)
+		if err != nil {
+			Fail("Cannot get hostname from the URL provided in TFE_ADDRESS")
+		}
+		cloudEndpoint = u.Host
+	}
 
 	By("bootstrapping test environment")
 	if os.Getenv("USE_EXISTING_CLUSTER") == "true" {


### PR DESCRIPTION
### Description

This PR adds a new GH workflow to run E2E tests on the TFE instance.

### Usage Example

N/A.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
`operator`: add a new GH workflow to run tests on the TFE instance.
```

### References

N/A.

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
