### PR TITLE
Update the CODEOWNERS file with the release engineering team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
+# Main codeowners
 * @hashicorp/terraform-ecosystem-kubernetes
+
+# release configuration
+/.release/                      @hashicorp/release-engineering
+/.github/workflows/build.yml    @hashicorp/release-engineering


### PR DESCRIPTION
### Description

Grant ownership to some files and directories to the release engineering team.

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
