### PR TITLE
🐛 Fix `ENTRYPOINT` and `COPY` layers in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ WORKDIR /
 COPY --from=dev-builder /build/$BIN_NAME .
 USER 65532:65532
 
-ENTRYPOINT ["/$BIN_NAME"]
+ENTRYPOINT ["/bin/sh", "-c", "/$BIN_NAME"]
 
 # ===================================
 #
@@ -70,7 +70,6 @@ FROM gcr.io/distroless/static:nonroot AS release-default
 ARG BIN_NAME
 ARG PRODUCT_VERSION
 ARG PRODUCT_REVISION
-ARG PRODUCT_NAME=$BIN_NAME
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -80,12 +79,13 @@ LABEL maintainer="Team Terraform Ecosystem - Kubernetes <team-tf-k8s@hashicorp.c
 LABEL version=$PRODUCT_VERSION
 LABEL revision=$PRODUCT_REVISION
 
+WORKDIR /
 COPY LICENSE /licenses/copyright.txt
-COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME /bin/
+COPY dist/$TARGETOS/$TARGETARCH/$BIN_NAME .
 
 USER 65532:65532
 
-ENTRYPOINT ["/$BIN_NAME"]
+ENTRYPOINT ["/bin/sh", "-c", "/$BIN_NAME"]
 
 # ===================================
 #


### PR DESCRIPTION
### Description

Fix an issue with the `ENTRYPOINT` in the Dockerfile and incorrect path when `COPY` the binary. In addition, remove unused `ARG` and add the `WORKDIR` layer for clarity.

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
