### PR TITLE
Add the ability to configure log levels via env var

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,8 @@ func main() {
 		if lerr == nil {
 			setupLog.Info("Set logging level to %q", ls)
 			zapConfig.Level = lv
+		} else {
+			setupLog.Error(lerr, "unable to set logging level")
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	LOG_LEVEL_VAR = "TF_LOG"
+	LOG_LEVEL_VAR = "TF_LOG_OPERATOR"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -33,6 +33,10 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
+const (
+	LOG_LEVEL_VAR = "TF_LOG"
+)
+
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
@@ -71,6 +75,14 @@ func main() {
 	zapConfig.Encoding = "console"
 	zapConfig.DisableCaller = true
 	zapConfig.DisableStacktrace = true
+
+	if ls, ok := os.LookupEnv(LOG_LEVEL_VAR); ok {
+		lv, lerr := zap.ParseAtomicLevel(ls)
+		if lerr == nil {
+			setupLog.Info("Set logging level to %q", ls)
+			zapConfig.Level = lv
+		}
+	}
 
 	logger, err := zapConfig.Build(zap.AddStacktrace(zapcore.DPanicLevel))
 	if err != nil {


### PR DESCRIPTION
### Description
<!---
Please describe your changes in detail.
--->
This change introduces the ability to set the logging level of the operator process through the well-known `TF_LOG` environment variable.

Feel free to suggest a new name for the environment variable if this one is not ideal.

### Usage Example
<!---
Please provide a usage example if you have implemented a new feature.
--->
```
TF_LOG=debug ./bin/manager
```
OR
```
kubectl patch deployment <tfc-deployment> -p '{"spec":{"template":{"spec":{containers:[{name:<operator-container>, env:["name": "TF_LOG", "env": "debug"]}]}}'
```
### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):
<!--
Please write a release note message.
If the change is not user-facing, leave "NONE" in the release-note block below.
-->

```release-note
* Add ability to set log level via environment variable.
```

### References
<!---
Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
For example:
 - Fixes: GH-0000
-->

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
