### PR TITLE
Add TF configuration for provisioning TFE test instance

### DIFF
--- a/.github/test-infra/tfe/README.md
+++ b/.github/test-infra/tfe/README.md
@@ -1,0 +1,63 @@
+# EXAMPLE: Standalone Mounted Installation of Terraform Enterprise
+
+## About This Example
+
+This example for Terraform Enterprise creates a TFE installation with the following traits:
+
+- Standalone
+- Mounted Disk production type
+- n1-standard-4 virtual machine type
+- Ubuntu 20.04
+- A publicly accessible HTTP load balancer with TLS termination
+
+
+## Prerequisites
+
+This example assumes that the following resources exist:
+
+- TFE license is on a file path defined by `var.license_file` 
+- A DNS zone
+- Valid managed SSL certificate to use with load balancer:
+  - Create/Import a managed SSL Certificate in Network Services -> Load Balancing to serve as the certificate for the DNS A Record.
+  
+## How to Use This Module
+
+### Deployment
+
+1. Read the entire [README.md](../../README.md) of the root module.
+2. Ensure account meets module prerequisites from above.
+3. Clone repository.
+4. Change directory into desired example folder.
+5. Create a local `terraform.auto.tfvars` file and instantiate the required inputs as in the respective `./examples/standalone-mounted/variables.tf` including the path to the license under the `license_file` variable value.
+6. Authenticate against the Google provider. See [instructions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#authentication).
+7. Initialize terraform and apply the module configurations using the commands below:
+
+  NOTE: `terraform plan` will print out the execution plan which describes the actions Terraform will take in order to build your infrastructure to match the module configuration. If anything in the plan seems incorrect or dangerous, it is safe to abort here and not proceed to `terraform apply`.
+
+  ```
+  terraform init
+  terraform plan
+  terraform apply
+  ```
+
+## Post-deployment Tasks
+
+The build should take approximately 10-15 minutes to deploy. Once the module has completed, give the platform another 10 minutes or so prior to attempting to interact with it in order for all containers to start up.
+
+Unless amended, this example will not create an initial admin user using the IACT, but it does output the URL for your convenience. Follow the advice in this document to create the initial admin user, and log into the system using this user in order to configure it for use.
+
+### Connecting to the TFE Console
+
+The TFE Console is only available in a standalone environment
+
+1. Navigate to the URL supplied via `tfe_console_url` Terraform output
+2. Copy the `tfe_console_password` Terraform output
+3. Enter the console password
+4. Click `Unlock`
+
+### Connecting to the TFE Application
+
+1. Navigate to the URL supplied via the `login_url` Terraform output. (It may take several minutes for this to be available after initial deployment. You may monitor the progress of cloud init if desired on one of the instances.)
+2. Enter a `username`, `email`, and `password` for the initial user.
+3. Click `Create an account`.
+4. After the initial user is created you may access the TFE Application normally using the URL supplied via `login_url` Terraform output.

--- a/.github/test-infra/tfe/README.md
+++ b/.github/test-infra/tfe/README.md
@@ -15,10 +15,9 @@ This example for Terraform Enterprise creates a TFE installation with the follow
 
 This example assumes that the following resources exist:
 
-- TFE license is on a file path defined by `var.license_file` 
-- A DNS zone
-- Valid managed SSL certificate to use with load balancer:
-  - Create/Import a managed SSL Certificate in Network Services -> Load Balancing to serve as the certificate for the DNS A Record.
+- TFE license is on a file path defined by `var.license_file`
+- A DNS zone (already provisioned and speficied in the auto.tfvars file)
+- Valid managed SSL certificate to use with load balancer (already provisioned and speficied in the auto.tfvars file)
   
 ## How to Use This Module
 
@@ -37,14 +36,24 @@ This example assumes that the following resources exist:
   ```
   terraform init
   terraform plan
-  terraform apply
+  terraform apply -auto-approve
   ```
 
 ## Post-deployment Tasks
 
 The build should take approximately 10-15 minutes to deploy. Once the module has completed, give the platform another 10 minutes or so prior to attempting to interact with it in order for all containers to start up.
 
-Unless amended, this example will not create an initial admin user using the IACT, but it does output the URL for your convenience. Follow the advice in this document to create the initial admin user, and log into the system using this user in order to configure it for use.
+Next comes creating the admin user. To do this, use the Terraform configuration in the `./initial-admin` sub-directory.
+DO NOT run a PLAN on this configuration. This is because the admin creation API calls are performed via datasource, which actually evaluate at plan time. Effectively, the admin user is created during the planning phase. Just run ONE SINGLE APPLY, that implies a single plan action.
+
+WARNING: please not the absence of the plan action!!! DO NOT RUN PLAN!
+
+```
+terraform init
+terraform apply -auto-approve
+```
+
+The output of this apply will print out the API token corresponding to the admin user.
 
 ### Connecting to the TFE Console
 

--- a/.github/test-infra/tfe/initial-admin/admin.tf
+++ b/.github/test-infra/tfe/initial-admin/admin.tf
@@ -1,0 +1,54 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "tfe-api-url" {
+  type    = string
+  default = "https://tfe.gcp.terraform-k8s-providers-ci.hashicorp.services/"
+}
+
+variable "admin_username" {
+  type    = string
+  default = "admin"
+}
+
+variable "admin_password" {
+  type = string
+  sensitive = true
+}
+
+variable "admin_email" {
+  type    = string
+}
+
+data "http" "wait-for-ok" {
+  url = "${var.tfe-api-url}/_health_check"
+  retry {
+    attempts     = 2000
+    min_delay_ms = 1000
+  }
+}
+
+data "http" "iact_token" {
+  url = "${var.tfe-api-url}/admin/retrieve-iact"
+  retry {
+    attempts     = 2000
+    min_delay_ms = 1000
+  }
+}
+
+data "http" "admin_user_token" {
+  url    = "${var.tfe-api-url}/admin/initial-admin-user?token=${data.http.iact_token.response_body}"
+  method = "POST"
+  request_headers = {
+    Content-Type = "application/json"
+  }
+  request_body = jsonencode({
+    username = var.admin_username
+    password = var.admin_password
+    email    = var.admin_email
+  })
+}
+
+output "admin_token" {
+  value = jsondecode(data.http.admin_user_token.response_body)
+}

--- a/.github/test-infra/tfe/initial-admin/admin.tf
+++ b/.github/test-infra/tfe/initial-admin/admin.tf
@@ -20,6 +20,8 @@ variable "admin_email" {
   type    = string
 }
 
+# Wait for the TFE installation to finish internal provisioning on the node and report itself as available.
+#
 data "http" "wait-for-ok" {
   url = "${var.tfe-api-url}/_health_check"
   retry {
@@ -28,6 +30,8 @@ data "http" "wait-for-ok" {
   }
 }
 
+# Grab the time-limited IACT token required to create the admin user.
+#
 data "http" "iact_token" {
   url = "${var.tfe-api-url}/admin/retrieve-iact"
   retry {
@@ -36,6 +40,8 @@ data "http" "iact_token" {
   }
 }
 
+# Create the admin user and retrieve its associated token
+#
 data "http" "admin_user_token" {
   url    = "${var.tfe-api-url}/admin/initial-admin-user?token=${data.http.iact_token.response_body}"
   method = "POST"
@@ -50,5 +56,5 @@ data "http" "admin_user_token" {
 }
 
 output "admin_token" {
-  value = jsondecode(data.http.admin_user_token.response_body)
+  value = jsondecode(data.http.admin_user_token.response_body).token
 }

--- a/.github/test-infra/tfe/main.tf
+++ b/.github/test-infra/tfe/main.tf
@@ -1,0 +1,44 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# Random String for unique names
+# ------------------------------
+resource "random_pet" "main" {
+  length = 1
+}
+
+# Store TFE License as secret
+# ---------------------------
+module "secrets" {
+  source = "github.com/hashicorp/terraform-google-terraform-enterprise/fixtures/secrets"
+
+  license = {
+    id   = random_pet.main.id
+    path = var.license_file
+  }
+}
+
+# Gets the external IP address of the provisioner
+# TFE requires this in order to accept admin creation API calls
+# -------------------------------------------------------------
+data "http" "icanhazip" {
+   url = "http://icanhazip.com"
+}
+
+# Standalone, mounted disk
+# ------------------------
+module "tfe" {
+  source = "github.com/hashicorp/terraform-google-terraform-enterprise"
+
+  distribution                = "ubuntu"
+  dns_zone_name               = var.dns_zone_name
+  existing_service_account_id = var.existing_service_account_id
+  namespace                   = random_pet.main.id
+  node_count                  = 1
+  fqdn                        = var.fqdn
+  load_balancer               = "PUBLIC"
+  ssl_certificate_name        = var.ssl_certificate_name
+  tfe_license_secret_id       = module.secrets.license_secret
+  vm_machine_type             = "n1-standard-4"
+  iact_subnet_list = tolist(["${chomp(data.http.icanhazip.body)}/32"])
+}

--- a/.github/test-infra/tfe/outputs.tf
+++ b/.github/test-infra/tfe/outputs.tf
@@ -1,0 +1,37 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+output "health_check_url" {
+  value       = module.tfe.health_check_url
+  description = "The URL of the Terraform Enterprise health check endpoint."
+}
+
+output "iact_notice" {
+  value       = "Once deployed, please follow this page to set the initial user up: https://www.terraform.io/docs/enterprise/install/automating-initial-user.html"
+  description = "Login advice message."
+}
+
+output "iact_url" {
+  value       = module.tfe.iact_url
+  description = "IACT URL"
+}
+
+output "initial_admin_user_url" {
+  value       = module.tfe.initial_admin_user_url
+  description = "Initial Admin user URL"
+}
+
+output "lb_address" {
+  value       = module.tfe.lb_address
+  description = "Load Balancer Address"
+}
+
+output "replicated_console_password" {
+  value       = module.tfe.replicated_console_password
+  description = "Generated password for replicated dashboard"
+}
+
+output "url" {
+  value       = module.tfe.url
+  description = "Login URL to setup the TFE instance once it is initialized"
+}

--- a/.github/test-infra/tfe/terraform.auto.tfvars
+++ b/.github/test-infra/tfe/terraform.auto.tfvars
@@ -1,0 +1,4 @@
+existing_service_account_id = "tfe-k8s-dev"
+fqdn                        = "tfe.gcp.terraform-k8s-providers-ci.hashicorp.services"
+dns_zone_name               = "gcp-terraform-k8s-providers-ci"
+ssl_certificate_name        = "tfe-api-k8s-20230503150723712400000001"

--- a/.github/test-infra/tfe/variables.tf
+++ b/.github/test-infra/tfe/variables.tf
@@ -1,0 +1,30 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "dns_zone_name" {
+  description = "The name of the DNS zone in which a record will be created."
+  type        = string
+}
+
+variable "existing_service_account_id" {
+  default     = null
+  type        = string
+  description = "The ID of the logging service account to use for compute resources deployed."
+}
+
+variable "fqdn" {
+  description = "The fully qualified domain name which will be assigned to the DNS record."
+  type        = string
+}
+
+variable "license_file" {
+  type        = string
+  description = "The local path to the Terraform Enterprise license."
+}
+
+variable "ssl_certificate_name" {
+  description = <<-EOD
+  The name of an existing SSL certificate which will be used to authenticate connections to the load balancer.
+  EOD
+  type        = string
+}

--- a/.github/test-infra/tfe/versions.tf
+++ b/.github/test-infra/tfe/versions.tf
@@ -1,0 +1,13 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_version = ">= 0.14"
+
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@
 # Directories
 bin/
 .vscode/
+.terraform
+
+# Terraform state 
+.terraform.lock.hcl
+terraform.tfstate*
 
 # Dependency directories (remove the comment below to include it)
 # vendor/


### PR DESCRIPTION
### Description
This add the ability to provision a TFE instance on Google Cloud to serve as a target for testing.

### Usage Example
<!---
Please provide a usage example if you have implemented a new feature.
--->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):
<!--
Please write a release note message.
If the change is not user-facing, leave "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References
<!---
Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
For example:
 - Fixes: GH-0000
-->
