### PR TITLE
🚀 Remove auto apply from Run to inherit it from the Workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0-beta6 (Unreleased)
+
+ENHANCEMENT:
+
+* `Module`: The Run now adopts the apply method of the Workspace in which it is executed. If the apply method is set to 'manual', the Run will remain on hold until it receives manual approval or rejection for the application or cancellation of the Run. [[GH-170](https://github.com/hashicorp/terraform-cloud-operator/pull/170)]
+
 ## 2.0.0-beta5 (April 18, 2023)
 
 BUG FIXES:

--- a/controllers/module_controller.go
+++ b/controllers/module_controller.go
@@ -472,8 +472,6 @@ func (r *ModuleReconciler) reconcileModule(ctx context.Context, m *moduleInstanc
 		run, err := m.tfClient.Client.Runs.Create(ctx, tfc.RunCreateOptions{
 			Message:   tfc.String("Triggered by the Kubernetes Operator"),
 			Workspace: workspace,
-			// Execute a new Run once it is created
-			AutoApply: tfc.Bool(true),
 		})
 		if err != nil {
 			m.log.Error(err, "Reconcile Run", "msg", "failed to create a new run")


### PR DESCRIPTION
### Description

This PR removed the automatically apply method from the `Module` when a new Run is executed. Instead, the apply method is now inherited from the Workspace in which the Run is executed.

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
`Module`: The Run now adopts the apply method of the Workspace in which it is executed. If the apply method is set to 'manual', the Run will remain on hold until it receives manual approval or rejection for the application or cancellation of the Run.
```

### References

- Fixes: https://github.com/hashicorp/terraform-cloud-operator/issues/83

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
