### PR TITLE
Add Helm chart value to configure custom CA certificates

### DIFF
--- a/charts/terraform-cloud-operator/templates/ca_secret.yaml
+++ b/charts/terraform-cloud-operator/templates/ca_secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.customCAcertificates -}}
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-ca-certificates
+  namespace: {{ .Release.Namespace }}
+data:
+  ca-certificates: |-
+{{ .Files.Get .Values.customCAcertificates | indent 4 }}
+
+{{- end }}

--- a/charts/terraform-cloud-operator/templates/deployment.yaml
+++ b/charts/terraform-cloud-operator/templates/deployment.yaml
@@ -68,6 +68,12 @@ spec:
           - mountPath: /controller_manager_config.yaml
             name: manager-config
             subPath: controller_manager_config.yaml
+{{- if .Values.customCAcertificates }}
+          - name: ca-certificates
+            mountPath: /etc/ssl/certs/custom-ca-certificates.crt
+            subPath: ca-certificates
+            readOnly: true
+{{- end }}
         - name: kube-rbac-proxy
           image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
           imagePullPolicy: IfNotPresent
@@ -97,3 +103,8 @@ spec:
       - configMap:
           name: {{ .Release.Name }}-manager-config
         name: manager-config
+{{- if .Values.customCAcertificates }}
+      - configMap:
+          name: {{ .Release.Name }}-ca-certificates
+        name: ca-certificates
+{{- end }}

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -39,3 +39,5 @@ controllers:
   workspace:
     # The number of the Workspace controller workers.
     workers: 1
+
+customCAcertificates: ""

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -40,4 +40,6 @@ controllers:
     # The number of the Workspace controller workers.
     workers: 1
 
+# Custom Certificate Authority bundle to validate API TLS certificates
+# Expects a path to a CRT file containing concatenated certificates
 customCAcertificates: ""

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -49,6 +49,13 @@ If targeting a TFE instance rather than Terraform Cloud, set the API URL using t
   --set operator.tfeAddress="https://tfe-api.my-company.com"
 ```
 
+If the TFE instance uses a TLS certificate signed by a non-public authority or "Let's Encrypt", the chain of CAs that can validate 
+that TLS certificate should be installed with the operator by setting the `customCAcertificates` chart value:
+
+```
+  --set customCAcertificates=<path-to-CA-chain-file.crt>
+``` 
+
 ### Upgrade with options
 
 ```console


### PR DESCRIPTION
### Description
Some TFE installations use TLS certificates signed by private Certificate Authorities.

In order for the Operator to work with these installations, it needs to be configured with custom CA bundles that include the root certificates for such private CAs. These are installed through Helm, as a ConfigMap object mounted as a volume on top of the container image for the Operator process.

### Usage Example
  ```
  $ helm install \
    demo hashicorp/terraform-cloud-operator \
    --namespace tfc-operator-system \
    --create-namespace \
    --set customCAcertificates=letsencrypt-bundle.crt
  ```

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):
<!--
Please write a release note message.
If the change is not user-facing, leave "NONE" in the release-note block below.
-->

```release-note
* Add Helm chart value to configure custom CA certificates
```

### References

TFECO-3990

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
