### PR TITLE
🤖 Update GHA workflow `build`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
           go-version-file: 'go.mod'
       - name: Go build
         uses: hashicorp/actions-go-build@e20c6be7bf010e40e930dab20e6da63176725ec1 # v0.1.9
+        env:
+          CGO_ENABLED: 0
         with:
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.set-product-version.outputs.product-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 2.0.0-beta6 (Unreleased)
+## 2.0.0-beta7 (UNRELEASED)
+
+BUG FIXES:
+
+* `Operator`: fix an issue when the operator couldn't be run on the `amd64` platform.
+
+## 2.0.0-beta6 (June 23, 2023)
 
 NOTES:
 * `Operator`: the Operator no longer includes the global option `--config`. [[GH-185](https://github.com/hashicorp/terraform-cloud-operator/pull/185)]


### PR DESCRIPTION
### Description

Fix an issue when the `manager` binary is built dynamically linked for the `amd64` platform and thus doesn't execute.

Here is how the binary looks like now:

```console
$ file manager

manager: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=6t7_Om9mjcdHWg5nl9dY/rwFCLkKjqObWsc7KzI7v/_FJeR4ElG29aEmXTBP2e/rcJTYNWa_iZQAwkP11cA, with debug_info, not stripped
```

And since we use `distroless` it can't be executed because `/lib64/ld-linux-x86-64.so.2` doesn't exist in this image.

Here is how the file looks like with this fix:

```console
$ file manager

manager: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=IbLk7KklHR72DlNfXW8b/IyNUnfopeH6XQBu5tQnG/swXq8XmOqairktuEMVYO/Di11ccuyOMrVlObJUf2B, with debug_info, not stripped
```

The following error could be observed:

```
exec /manager: no such file or directory
```

Link this PR to the issue that triggered investigation: https://github.com/hashicorp/terraform-cloud-operator/issues/193.

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
`Operator`: fix an issue when the operator couldn't be run on the `amd64` platform.
```

### References

Address: https://github.com/hashicorp/terraform-cloud-operator/issues/193

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
