### PR TITLE
🚀 Add `status.TerraformVersion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ BUG FIXES:
 
 ENHANCEMENT:
 
-* * `Workspace`: add Terraform version utilized in the Workspace to the status: `status.TerraformVersion`. [[GH-206](https://github.com/hashicorp/terraform-cloud-operator/pull/206)]
+* `Workspace`: add Terraform version utilized in the Workspace to the status: `status.TerraformVersion`. [[GH-206](https://github.com/hashicorp/terraform-cloud-operator/pull/206)]
+
+DOCS:
+
+* Update FAQ. [[GH-206](https://github.com/hashicorp/terraform-cloud-operator/pull/206)]
 
 ## 2.0.0-beta6 (June 23, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ BUG FIXES:
 
 * `Operator`: fix an issue when the operator couldn't be run on the `amd64` platform.
 
+ENHANCEMENT:
+
+* * `Workspace`: add Terraform version utilized in the Workspace to the status: `status.TerraformVersion`. [[GH-206](https://github.com/hashicorp/terraform-cloud-operator/pull/206)]
+
 ## 2.0.0-beta6 (June 23, 2023)
 
 NOTES:

--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -493,14 +493,22 @@ type WorkspaceStatus struct {
 	WorkspaceID string `json:"workspaceID"`
 
 	// Real world state generation.
+	//
 	//+optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// Workspace last update timestamp.
+	//
 	//+optional
 	UpdateAt int64 `json:"updateAt,omitempty"`
 	// Workspace Runs status.
+	//
 	//+optional
 	Run RunStatus `json:"runStatus,omitempty"`
+	// Workspace Terraform version.
+	//
+	//+kubebuilder:validation:Pattern:="^\\d{1}\\.\\d{1,2}\\.\\d{1,2}$"
+	//+optional
+	TerraformVersion string `json:"terraformVersion,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/charts/terraform-cloud-operator/crds/app.terraform.io_workspaces.yaml
+++ b/charts/terraform-cloud-operator/crds/app.terraform.io_workspaces.yaml
@@ -594,6 +594,10 @@ spec:
                       run status.
                     type: string
                 type: object
+              terraformVersion:
+                description: Workspace Terraform version.
+                pattern: ^\d{1}\.\d{1,2}\.\d{1,2}$
+                type: string
               updateAt:
                 description: Workspace last update timestamp.
                 format: int64

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -591,6 +591,10 @@ spec:
                       run status.
                     type: string
                 type: object
+              terraformVersion:
+                description: Workspace Terraform version.
+                pattern: ^\d{1}\.\d{1,2}\.\d{1,2}$
+                type: string
               updateAt:
                 description: Workspace last update timestamp.
                 format: int64

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -141,6 +141,14 @@
 
   Non-sensitive outputs will be saved in a ConfigMap. Sensitive outputs will be saved in a Secret. In both cases, the name of the corresponding Kubernetes resource will be generated automatically and has the following pattern: `<metadata.name>-outputs`.
 
+- **What version of Terraform is utilized in the Workplace?**
+
+  If the `spec.terraformVersion` is configured, the Operator ensures that the specified version will be utilized.
+
+  If the `spec.terraformVersion` is not configured, i.e. empty, the latest available Terraform version will be picked up during the Workspace creation and the same version will be utilized till it gets updated via the Workspace manifest.
+
+  Regardless of the scenario, you can always refer to `status.terraformVersion` to determine the version of Terraform being used in the Workplace.
+
 ## Module Controller
 
 - **Where can I find Module outputs?**

--- a/docs/migration/crds/workspaces_patch_a.yaml
+++ b/docs/migration/crds/workspaces_patch_a.yaml
@@ -890,6 +890,10 @@ spec:
                   description: Real world state generation.
                   format: int64
                   type: integer
+                terraformVersion:
+                  description: Workspace Terraform version.
+                  pattern: ^\d{1}\.\d{1,2}\.\d{1,2}$
+                  type: string
                 updateAt:
                   description: Workspace last update timestamp.
                   format: int64

--- a/docs/migration/crds/workspaces_patch_b.yaml
+++ b/docs/migration/crds/workspaces_patch_b.yaml
@@ -907,6 +907,10 @@ spec:
                         run status.
                       type: string
                   type: object
+                terraformVersion:
+                  description: Workspace Terraform version.
+                  pattern: ^\d{1}\.\d{1,2}\.\d{1,2}$
+                  type: string
                 updateAt:
                   description: Workspace last update timestamp.
                   format: int64

--- a/main.go
+++ b/main.go
@@ -105,8 +105,8 @@ func main() {
 			setupLog.Info("does not run in a Kubernetes environment")
 			options.LeaderElectionNamespace = "default"
 		} else {
-			// Ignore all other errors but print them out
-			setupLog.Info("got an error when called InClusterConfig:", err)
+			// Ignore all other errors since it is affect only the dev end but print them out.
+			setupLog.Info("got an error when calling InClusterConfig:", err)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -93,6 +94,20 @@ func main() {
 		LeaderElection:                true,
 		LeaderElectionReleaseOnCancel: true,
 		LeaderElectionID:              "hashicorp-terraform-cloud-operator",
+	}
+
+	// When the Operator not running in a Kubernetes environment,
+	// i.e. during the development stage when it runs via the command 'make run',
+	// It requires a namespace to be specified for the Leader Election.
+	// We set it up to 'default' since this namespace always presents.
+	if _, err := rest.InClusterConfig(); err != nil {
+		if err == rest.ErrNotInCluster {
+			setupLog.Info("does not run in a Kubernetes environment")
+			options.LeaderElectionNamespace = "default"
+		} else {
+			// Ignore all other errors but print them out
+			setupLog.Info("got an error when called InClusterConfig:", err)
+		}
 	}
 
 	if len(watchNamespaces) != 0 {


### PR DESCRIPTION
### Description

Add a new field to the `status` to reflect the Terraform version utilized in the Workspace.

This PR includes the following changes:

- Update FAQ regarding the Terraform version utilized in the Workspace.
- Add Terraform version utilized in the Workspace to the status: `status.TerraformVersion`.
- Fix an issue when the Operator couldn't start on a local machine during development. Introduced in https://github.com/hashicorp/terraform-cloud-operator/pull/185.

### Usage Example

```console
$ kubectl get workspace this -o yaml

...
status:
  observedGeneration: 1
  runStatus: {}
  terraformVersion: 1.5.1
  updateAt: 1688463765
  workspaceID: ws-XpQnRpW81rnJMGob
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
`Workspace`: add Terraform version utilized in the Workspace to the status: `status.TerraformVersion`.
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
