### PR TITLE
🚀 Support autoscaling agents to 0 replicas

### DIFF
--- a/controllers/agentpool_controller_autoscaling.go
+++ b/controllers/agentpool_controller_autoscaling.go
@@ -6,6 +6,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	tfc "github.com/hashicorp/go-tfe"
@@ -19,8 +20,13 @@ import (
 )
 
 func getWorkspacePendingRuns(ctx context.Context, ap *agentPoolInstance, workspaceID string) (int, error) {
+	statuses := []string{
+		string(tfc.RunPending),
+		string(tfc.RunPlanQueued),
+		string(tfc.RunApplyQueued),
+	}
 	runs, err := ap.tfClient.Client.Runs.List(ctx, workspaceID, &tfc.RunListOptions{
-		Status: string(tfc.RunPending),
+		Status: strings.Join(statuses, ","),
 	})
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

### Description
<!---
Please describe your changes in detail.
--->
When there are no agents available to pick up a run the status of the runs are pending. This PR adds additional statuses to trigger a scaling event; `plan_queued` and `apply_queued`.

### Usage Example
<!---
Please provide a usage example if you have implemented a new feature.
--->
Saving resource in Kubernetes by scaling down to 0 when there are no runs pending.

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):
<!--
Please write a release note message.
If the change is not user-facing, leave "NONE" in the release-note block below.
-->

```release-note
Support autoscaling agents to 0 replicas
```

### References
<!---
Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
For example:
 - Fixes: GH-0000
-->
N/A

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
