### PR TITLE
🐛 Remove duplicate key `name` in the Helm chart's Deployment template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0-beta8 (UNRELEASED)
+
+BUG FIXES:
+* `AgentPool`: fix an issue when `plan_queued` and `apply_queued` statuses do not trigger agent scaling. [[GH-215](https://github.com/hashicorp/terraform-cloud-operator/pull/215)]
+* `Helm Chart`: fix an issue with the Deployment template in the Helm chart where `name` in path `spec.template.spec.containers[0]` was duplicated. [[GH-216](https://github.com/hashicorp/terraform-cloud-operator/pull/216)]
+
 ## 2.0.0-beta7 (July 07, 2023)
 
 NOTES:

--- a/charts/terraform-cloud-operator/templates/deployment.yaml
+++ b/charts/terraform-cloud-operator/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         control-plane: {{ .Release.Name }}-controller-manager
     spec:
       containers:
-        - name: {{ .Chart.Name }}
+        - name: manager
           image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           args:
@@ -52,7 +52,6 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
-          name: manager
           readinessProbe:
             httpGet:
               path: /readyz


### PR DESCRIPTION
### Description

The helm charts `deployment.yaml` includes a `name` key on the container spec twice. Typically this seems to be fine when using helm and applying it to Kubernetes but this causes problems if you want to use Kustomize to apply additional patches.

I'm not entirely sure the container name needs to be based on the chart name `{{ .Chart.Name }}` so I've just set this as `manager`.

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
`Helm Chart`: fix an issue with the Deployment template in the Helm chart where `name` in path `spec.template.spec.containers[0]` was duplicated.
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
