### PR TITLE
🚀 Add a new environment variable `TFC_TLS_SKIP_VERIFY`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0-beta8 (UNRELEASED)
+
+ENHANCEMENT:
+* `Operator`: Add the ability to skip TLS certificate validation for communication between the Operator and the TFC/E endpoint. A new environment variable `TFC_TLS_SKIP_VERIFY` should be set to `true` to skip the validation. Default: `false`. [[GH-222](https://github.com/hashicorp/terraform-cloud-operator/pull/222)]
+* `Helm Chart`: Add a new parameter `operator.skipTLSVerify` to configure the ability to skip TLS certificate validation for communication between the Operator and the TFC/E endpoint. Default: `false`. [[GH-222](https://github.com/hashicorp/terraform-cloud-operator/pull/222)]
+
 ## 2.0.0-beta7 (July 07, 2023)
 
 NOTES:

--- a/charts/terraform-cloud-operator/templates/deployment.yaml
+++ b/charts/terraform-cloud-operator/templates/deployment.yaml
@@ -37,11 +37,14 @@ spec:
           {{- if .Values.operator.tfeAddress }}
             {{- $_ := set $envVars "TFE_ADDRESS" .Values.operator.tfeAddress }}
           {{- end }}
+          {{- if .Values.operator.skipTLSVerify }}
+            {{- $_ := set $envVars "TFC_TLS_SKIP_VERIFY" .Values.operator.skipTLSVerify }}
+          {{- end }}
           {{- if gt (len (keys $envVars)) 0 }}
           env:
             {{- range $ek, $ev := $envVars }}
             - name: {{ $ek }}
-              value: {{ $ev -}}
+              value: "{{ $ev -}}"
             {{ end }}
           {{- end }}
           command:

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -28,6 +28,9 @@ operator:
   # The API URL of a TFE instance
   tfeAddress: ""
 
+  # Whether or not to ignore TLS certification warnings.
+  skipTLSVerify: false
+
 # Controllers-specific options.
 controllers:
   agentPool:

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -5,7 +5,11 @@ package controllers
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
+	"os"
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -160,8 +164,25 @@ func (r *WorkspaceReconciler) getTerraformClient(ctx context.Context, w *workspa
 		return err
 	}
 
+	httpClient := tfc.DefaultConfig().HTTPClient
+	insecure := false
+
+	if v, ok := os.LookupEnv("TFC_TLS_SKIP_VERIFY"); ok {
+		insecure, err = strconv.ParseBool(v)
+		if err != nil {
+			return err
+		}
+	}
+
+	if insecure {
+		w.log.Info("Reconcile Workspace", "msg", "client configured to skip TLS certificate verifications")
+	}
+
+	httpClient.Transport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
+
 	config := &tfc.Config{
-		Token: token,
+		Token:      token,
+		HTTPClient: httpClient,
 	}
 	w.tfClient.Client, err = tfc.NewClient(config)
 


### PR DESCRIPTION
### Description
<!---
Please describe your changes in detail.
--->

### Usage Example

```console
$ helm install demo hashicorp/terraform-cloud-operator --set operator.skipTLSVerify=true

$ helm upgrade demo hashicorp/terraform-cloud-operator --set operator.skipTLSVerify=true
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
`Operator`: Add the ability to skip TLS certificate validation for communication between the Operator and the TFC/E endpoint. A new environment variable `TFC_TLS_SKIP_VERIFY` should be set to `true` to skip the validation. Default: `false`.

`Helm Chart`: Add a new parameter `operator.skipTLSVerify` to configure the ability to skip TLS certificate validation for communication between the Operator and the TFC/E endpoint. Default: `false`.
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
