### PR TITLE
🤖 Update tests and related GH test workflows

### DIFF
--- a/.github/workflows/end-to-end-tfc.yaml
+++ b/.github/workflows/end-to-end-tfc.yaml
@@ -2,13 +2,12 @@ name: E2E on Terraform Cloud
 
 on:
   schedule:
-    - cron: '30 5 * * *'
-  pull_request:
-    branches:
-      - main
+    - cron: '30 5 * * 0'
   push:
     branches:
       - main
+    paths:
+      - 'controllers/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/end-to-end-tfe.yaml
+++ b/.github/workflows/end-to-end-tfe.yaml
@@ -2,13 +2,12 @@ name: E2E on Terraform Enterprise
 
 on:
   schedule:
-    - cron: '30 5 * * *'
-  pull_request:
-    branches:
-      - main
+    - cron: '30 5 * * 0'
   push:
     branches:
       - main
+    paths:
+      - 'controllers/**'
   workflow_dispatch:
 
 jobs:
@@ -33,3 +32,4 @@ jobs:
           TFC_TOKEN: ${{ secrets.TFE_TOKEN }}
           TFC_VCS_REPO: ${{ secrets.TFE_VCS_REPO }}
           TFE_ADDRESS: ${{ secrets.TFE_ADDRESS }}
+          TFC_TLS_SKIP_VERIFY: true

--- a/.github/workflows/helm-end-to-end-tfc.yaml
+++ b/.github/workflows/helm-end-to-end-tfc.yaml
@@ -2,19 +2,20 @@ name: E2E on Terraform Cloud [Helm]
 
 on:
   schedule:
-    - cron: '30 6 * * *'
-  pull_request:
-    branches:
-      - main
+    - cron: '30 6 * * 0'
   push:
     branches:
       - main
+    paths:
+      - 'controllers/**'
+      - 'charts/terraform-cloud-operator/**'
   workflow_dispatch:
 
 env:
   USE_EXISTING_CLUSTER: true
   CLUSTER_NAME: 'this'
   DOCKER_IMAGE: 'this'
+  KIND_VERSION: ${{ vars.KIND_VERSION }}
   KUBECONFIG: ${{ github.workspace }}/.kube/config
 
 jobs:
@@ -36,7 +37,7 @@ jobs:
         uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
         with:
           wait: 2m
-          version: v0.18.0 # Installs Kubernetes v1.26.3
+          version: v${{ env.KIND_VERSION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
 
       - name: Set up Helm

--- a/.github/workflows/helm-end-to-end-tfe.yaml
+++ b/.github/workflows/helm-end-to-end-tfe.yaml
@@ -2,19 +2,20 @@ name: E2E on Terraform Enterprise [Helm]
 
 on:
   schedule:
-    - cron: '30 6 * * *'
-  pull_request:
-    branches:
-      - main
+    - cron: '30 6 * * 0'
   push:
     branches:
       - main
+    paths:
+      - 'controllers/**'
+      - 'charts/terraform-cloud-operator/**'
   workflow_dispatch:
 
 env:
   USE_EXISTING_CLUSTER: true
   CLUSTER_NAME: 'this'
   DOCKER_IMAGE: 'this'
+  KIND_VERSION: ${{ vars.KIND_VERSION }}
   KUBECONFIG: ${{ github.workspace }}/.kube/config
 
 jobs:
@@ -36,7 +37,7 @@ jobs:
         uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
         with:
           wait: 2m
-          version: v0.18.0 # Installs Kubernetes v1.26.3
+          KIND_VERSION: ${{ vars.KIND_VERSION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
 
       - name: Set up Helm
@@ -91,3 +92,4 @@ jobs:
           TFC_TOKEN: ${{ secrets.TFC_TOKEN }}
           TFC_VCS_REPO: ${{ secrets.TFC_VCS_REPO }}
           TFE_ADDRESS: ${{ secrets.TFE_ADDRESS }}
+          TFC_TLS_SKIP_VERIFY: true

--- a/controllers/module_controller_test.go
+++ b/controllers/module_controller_test.go
@@ -25,6 +25,9 @@ var _ = Describe("Module controller", Ordered, func() {
 	)
 
 	BeforeAll(func() {
+		if cloudEndpoint != tfcDefaultAddress {
+			Skip("Does not run against TFC, skip this test")
+		}
 		// Set default Eventually timers
 		SetDefaultEventuallyTimeout(syncPeriod * 4)
 		SetDefaultEventuallyPollingInterval(2 * time.Second)
@@ -54,7 +57,7 @@ var _ = Describe("Module controller", Ordered, func() {
 					},
 				},
 				Module: &appv1alpha2.ModuleSource{
-					Source:  fmt.Sprintf("%s/%v/module-random/provider", cloudEndpoint, organization),
+					Source:  "github.com/arybolovlev/terraform-provider-module-random",
 					Version: "0.0.4",
 				},
 				DestroyOnDeletion: true,

--- a/controllers/workspace_controller_notifications_test.go
+++ b/controllers/workspace_controller_notifications_test.go
@@ -5,7 +5,6 @@ package controllers
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -92,6 +91,9 @@ var _ = Describe("Workspace controller", Label("Notifications"), Ordered, func()
 		})
 
 		It("can create multiple notifications", func() {
+			if cloudEndpoint != tfcDefaultAddress {
+				Skip("Does not run against TFC, skip this test")
+			}
 			instance.Spec.Notifications = append(instance.Spec.Notifications, appv1alpha2.Notification{
 				Name: "slack",
 				Type: tfc.NotificationDestinationTypeSlack,
@@ -109,6 +111,9 @@ var _ = Describe("Workspace controller", Label("Notifications"), Ordered, func()
 		})
 
 		It("can re-create notifications", func() {
+			if cloudEndpoint != tfcDefaultAddress {
+				Skip("Does not run against TFC, skip this test")
+			}
 			instance.Spec.Notifications = append(instance.Spec.Notifications, appv1alpha2.Notification{
 				Name: "slack",
 				Type: tfc.NotificationDestinationTypeSlack,
@@ -132,6 +137,9 @@ var _ = Describe("Workspace controller", Label("Notifications"), Ordered, func()
 		})
 
 		It("can update notifications", func() {
+			if cloudEndpoint != tfcDefaultAddress {
+				Skip("Does not run against TFC, skip this test")
+			}
 			instance.Spec.Notifications = append(instance.Spec.Notifications, appv1alpha2.Notification{
 				Name:       "email",
 				Type:       tfc.NotificationDestinationTypeEmail,
@@ -150,6 +158,9 @@ var _ = Describe("Workspace controller", Label("Notifications"), Ordered, func()
 		})
 
 		It("can delete notifications", func() {
+			if cloudEndpoint != tfcDefaultAddress {
+				Skip("Does not run against TFC, skip this test")
+			}
 			instance.Spec.Notifications = append(instance.Spec.Notifications, appv1alpha2.Notification{
 				Name:       "email",
 				Type:       tfc.NotificationDestinationTypeEmail,
@@ -168,8 +179,8 @@ var _ = Describe("Workspace controller", Label("Notifications"), Ordered, func()
 		})
 
 		It("can create Terraform Enterprise email address notifications", func() {
-			if _, ok := os.LookupEnv("TFE_ADDRESS"); !ok {
-				Skip("Environment variable TFE_ADDRESS is either not set or empty")
+			if cloudEndpoint == tfcDefaultAddress {
+				Skip("Does not run against TFC, skip this test")
 			}
 			instance.Spec.Notifications = append(instance.Spec.Notifications, appv1alpha2.Notification{
 				Name:           "email",

--- a/controllers/workspace_controller_outputs_test.go
+++ b/controllers/workspace_controller_outputs_test.go
@@ -32,6 +32,9 @@ var _ = Describe("Workspace controller", Ordered, func() {
 	})
 
 	BeforeEach(func() {
+		if cloudEndpoint != tfcDefaultAddress {
+			Skip("Does not run against TFC, skip this test")
+		}
 		// Create a new workspace object for each test
 		instance = &appv1alpha2.Workspace{
 			TypeMeta: metav1.TypeMeta{

--- a/controllers/workspace_controller_test.go
+++ b/controllers/workspace_controller_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			instance.Spec.AllowDestroyPlan = false
 			instance.Spec.Description = fmt.Sprintf("%v-new", instance.Spec.Description)
 			instance.Spec.ExecutionMode = "local"
-			instance.Spec.TerraformVersion = "1.5.2"
+			instance.Spec.TerraformVersion = "1.4.4"
 			instance.Spec.WorkingDirectory = fmt.Sprintf("%v/new", instance.Spec.WorkingDirectory)
 			Expect(k8sClient.Update(ctx, instance)).Should(Succeed())
 
@@ -148,7 +148,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 		})
 
 		It("can keep Terraform version", func() {
-			instance.Spec.TerraformVersion = "1.5.1"
+			instance.Spec.TerraformVersion = "1.4.1"
 			// Create a new Kubernetes workspace object and wait until the controller finishes the reconciliation
 			createWorkspace(instance, namespacedName)
 


### PR DESCRIPTION
### Description

Tests:

- Add the ability to skip TLS certificate validation and align tests with the TFE environment we have in place.

Workflows:

- Update `end-to-end-*` GH workflows to make them less noisy but still efficient whenever there are any changes.

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

Depends on: https://github.com/hashicorp/terraform-cloud-operator/pull/222

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
