### PR TITLE
🚀 Move helper functions to `utils/`

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,4 +1,4 @@
-name: API tests
+name: Unit tests
 
 on:
   schedule:
@@ -25,5 +25,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Run API tests
-        run: make test-api
+      - name: Run Unit tests
+        run: |
+          make test-api
+          make test-utils

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ test: manifests generate fmt vet copywrite envtest ## Run tests.
 test-api: fmt vet copywrite ## Run API tests.
 	go test -timeout 30m -count 1 -v ./api/v1alpha2
 
+.PHONY: test-utils
+test-utils: fmt vet copywrite ## Run API tests.
+	go test -timeout 30m -count 1 -v ./utils
+
 ##@ Build
 
 .PHONY: build

--- a/api/v1alpha2/agentpool_validation_test.go
+++ b/api/v1alpha2/agentpool_validation_test.go
@@ -5,6 +5,8 @@ package v1alpha2
 
 import (
 	"testing"
+
+	"github.com/hashicorp/terraform-cloud-operator/utils"
 )
 
 func TestValidateAgentPoolSpecAgentToken(t *testing.T) {
@@ -56,7 +58,7 @@ func TestValidateAgentPoolSpecAgentToken(t *testing.T) {
 				AgentTokens: []*AgentToken{
 					{
 						Name:      "this",
-						CreatedAt: PointerOf(int64(1984)),
+						CreatedAt: utils.PointerOf(int64(1984)),
 					},
 				},
 			},
@@ -66,7 +68,7 @@ func TestValidateAgentPoolSpecAgentToken(t *testing.T) {
 				AgentTokens: []*AgentToken{
 					{
 						Name:       "this",
-						LastUsedAt: PointerOf(int64(1984)),
+						LastUsedAt: utils.PointerOf(int64(1984)),
 					},
 				},
 			},

--- a/controllers/agentpool_controller_autoscaling.go
+++ b/controllers/agentpool_controller_autoscaling.go
@@ -14,9 +14,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 
 	appv1alpha2 "github.com/hashicorp/terraform-cloud-operator/api/v1alpha2"
+	"github.com/hashicorp/terraform-cloud-operator/utils"
 )
 
 func getWorkspaceQueueDepth(ctx context.Context, ap *agentPoolInstance, workspaceID string) (int, error) {
@@ -135,7 +135,7 @@ func (r *AgentPoolReconciler) reconcileAgentAutoscaling(ctx context.Context, ap 
 	} else if (int(*currentReplicas) + queueDepth) > int(*ap.instance.Spec.AgentDeploymentAutoscaling.MaxReplicas) {
 		desiredReplicas = ap.instance.Spec.AgentDeploymentAutoscaling.MaxReplicas
 	} else if queueDepth > int(*currentReplicas) {
-		desiredReplicas = pointer.Int32(int32(int(*currentReplicas) + queueDepth))
+		desiredReplicas = utils.PointerOf(int32(int(*currentReplicas) + queueDepth))
 	}
 
 	if *desiredReplicas != *currentReplicas {

--- a/controllers/agentpool_controller_deployment.go
+++ b/controllers/agentpool_controller_deployment.go
@@ -16,9 +16,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/hashicorp/terraform-cloud-operator/utils"
 )
 
 const (
@@ -121,7 +122,7 @@ func (r *AgentPoolReconciler) deleteDeployment(ctx context.Context, ap *agentPoo
 }
 
 func agentPoolDeployment(ap *agentPoolInstance) *appsv1.Deployment {
-	var r *int32 = pointer.Int32(1) // default to one replica if not otherwise configured
+	var r *int32 = utils.PointerOf(int32(1)) // default to one replica if not otherwise configured
 	if ap.instance.Spec.AgentDeployment.Replicas != nil {
 		r = ap.instance.Spec.AgentDeployment.Replicas
 	}
@@ -159,7 +160,7 @@ func agentPoolDeployment(ap *agentPoolInstance) *appsv1.Deployment {
 				RollingUpdate: &appsv1.RollingUpdateDeployment{
 					// this is important to ensure the number of pods does not temporarily
 					// shoot over the max agents allowed when rolling the deployment.
-					MaxSurge: appv1alpha2.PointerOf(intstr.FromInt(0)),
+					MaxSurge: utils.PointerOf(intstr.FromInt(0)),
 				},
 			},
 			Template: corev1.PodTemplateSpec{

--- a/controllers/agentpool_controller_test.go
+++ b/controllers/agentpool_controller_test.go
@@ -19,6 +19,7 @@ import (
 
 	tfc "github.com/hashicorp/go-tfe"
 	appv1alpha2 "github.com/hashicorp/terraform-cloud-operator/api/v1alpha2"
+	"github.com/hashicorp/terraform-cloud-operator/utils"
 )
 
 var _ = Describe("Agent Pool controller", Ordered, func() {
@@ -284,7 +285,7 @@ var _ = Describe("Agent Pool controller", Ordered, func() {
 
 			// ADD EMPTY AgentDeployment BLOCK
 			instance.Spec.AgentDeployment = &appv1alpha2.AgentDeployment{
-				Replicas: appv1alpha2.PointerOf(int32(3)),
+				Replicas: utils.PointerOf(int32(3)),
 			}
 			Expect(k8sClient.Update(ctx, instance)).Should(Succeed())
 
@@ -372,9 +373,9 @@ var _ = Describe("Agent Pool controller", Ordered, func() {
 				TargetWorkspaces: []appv1alpha2.TargetWorkspace{
 					{Name: "test-workspace"},
 				},
-				MinReplicas:           appv1alpha2.PointerOf(int32(3)),
-				MaxReplicas:           appv1alpha2.PointerOf(int32(5)),
-				CooldownPeriodSeconds: appv1alpha2.PointerOf(int32(60)),
+				MinReplicas:           utils.PointerOf(int32(3)),
+				MaxReplicas:           utils.PointerOf(int32(5)),
+				CooldownPeriodSeconds: utils.PointerOf(int32(60)),
 			}
 			Expect(k8sClient.Update(ctx, instance)).Should(Succeed())
 
@@ -386,9 +387,9 @@ var _ = Describe("Agent Pool controller", Ordered, func() {
 			Expect(instance.Spec.AgentDeploymentAutoscaling.TargetWorkspaces).To(Equal([]appv1alpha2.TargetWorkspace{
 				{Name: "test-workspace"},
 			}))
-			Expect(instance.Spec.AgentDeploymentAutoscaling.MinReplicas).To(Equal(appv1alpha2.PointerOf(int32(3))))
-			Expect(instance.Spec.AgentDeploymentAutoscaling.MaxReplicas).To(Equal(appv1alpha2.PointerOf(int32(5))))
-			Expect(instance.Spec.AgentDeploymentAutoscaling.CooldownPeriodSeconds).To(Equal(appv1alpha2.PointerOf(int32(60))))
+			Expect(instance.Spec.AgentDeploymentAutoscaling.MinReplicas).To(Equal(utils.PointerOf(int32(3))))
+			Expect(instance.Spec.AgentDeploymentAutoscaling.MaxReplicas).To(Equal(utils.PointerOf(int32(5))))
+			Expect(instance.Spec.AgentDeploymentAutoscaling.CooldownPeriodSeconds).To(Equal(utils.PointerOf(int32(60))))
 		})
 	})
 })

--- a/controllers/agentpool_controller_tokens.go
+++ b/controllers/agentpool_controller_tokens.go
@@ -14,6 +14,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/hashicorp/terraform-cloud-operator/utils"
 )
 
 func getAgentPoolTokens(ctx context.Context, ap *agentPoolInstance) (map[string]bool, error) {
@@ -105,8 +107,8 @@ func (r *AgentPoolReconciler) createAgentPoolTokens(ctx context.Context, ap *age
 		ap.instance.Status.AgentTokens = append(ap.instance.Status.AgentTokens, &appv1alpha2.AgentToken{
 			Name:       at.Description,
 			ID:         at.ID,
-			CreatedAt:  appv1alpha2.PointerOf(at.CreatedAt.Unix()),
-			LastUsedAt: appv1alpha2.PointerOf(at.LastUsedAt.Unix()),
+			CreatedAt:  utils.PointerOf(at.CreatedAt.Unix()),
+			LastUsedAt: utils.PointerOf(at.LastUsedAt.Unix()),
 		})
 		ap.log.Info("Reconcile Agent Tokens", "msg", fmt.Sprintf("successfully created a new agent token %q %q", t, at.ID))
 		// UPDATE SECRET

--- a/controllers/workspace_controller_notifications.go
+++ b/controllers/workspace_controller_notifications.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	tfc "github.com/hashicorp/go-tfe"
 
-	appv1alpha2 "github.com/hashicorp/terraform-cloud-operator/api/v1alpha2"
+	"github.com/hashicorp/terraform-cloud-operator/utils"
 )
 
 func hasNotificationItem(s []tfc.NotificationConfiguration, f tfc.NotificationConfiguration) (int, bool) {
@@ -34,7 +34,7 @@ func notificationsDifference(a, b []tfc.NotificationConfiguration) []tfc.Notific
 	for _, av := range a {
 		i, t := hasNotificationItem(bc, av)
 		if t {
-			bc = appv1alpha2.RemoveFromSlice(bc, i)
+			bc = utils.RemoveFromSlice(bc, i)
 		} else {
 			d = append(d, av)
 		}

--- a/utils/helpers.go
+++ b/utils/helpers.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package v1alpha2
+package utils
 
 func PointerOf[A any](a A) *A {
 	return &a

--- a/utils/helpers_test.go
+++ b/utils/helpers_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package v1alpha2
+package utils
 
 import (
 	"reflect"


### PR DESCRIPTION
### Description

Move genetic helper functions to `utils/`.

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
