### PR TITLE
🚀 Move helper functions to `internal/`

### DIFF
--- a/.github/workflows/helm-end-to-end-tfc.yaml
+++ b/.github/workflows/helm-end-to-end-tfc.yaml
@@ -15,7 +15,6 @@ env:
   USE_EXISTING_CLUSTER: true
   CLUSTER_NAME: 'this'
   DOCKER_IMAGE: 'this'
-  KIND_VERSION: ${{ vars.KIND_VERSION }}
   KUBECONFIG: ${{ github.workspace }}/.kube/config
 
 jobs:
@@ -37,7 +36,7 @@ jobs:
         uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
         with:
           wait: 2m
-          version: v${{ env.KIND_VERSION }}
+          version: v${{ vars.KIND_VERSION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
 
       - name: Set up Helm

--- a/.github/workflows/helm-end-to-end-tfe.yaml
+++ b/.github/workflows/helm-end-to-end-tfe.yaml
@@ -15,7 +15,6 @@ env:
   USE_EXISTING_CLUSTER: true
   CLUSTER_NAME: 'this'
   DOCKER_IMAGE: 'this'
-  KIND_VERSION: ${{ vars.KIND_VERSION }}
   KUBECONFIG: ${{ github.workspace }}/.kube/config
 
 jobs:
@@ -37,7 +36,7 @@ jobs:
         uses: helm/kind-action@fa81e57adff234b2908110485695db0f181f3c67 # v1.7.0
         with:
           wait: 2m
-          KIND_VERSION: ${{ vars.KIND_VERSION }}
+          version: v${{ vars.KIND_VERSION }}
           cluster_name: ${{ env.CLUSTER_NAME }}
 
       - name: Set up Helm
@@ -79,6 +78,8 @@ jobs:
           helm install --wait --timeout 1m this ./charts/terraform-cloud-operator \
             --set operator.image.repository=${{ env.DOCKER_IMAGE }} \
             --set operator.image.tag=${{ env.DOCKER_METADATA_OUTPUT_VERSION }} \
+            --set operator.skipTLSVerify=true \
+            --set operator.tfeAddress=${{ secrets.TFE_ADDRESS }} \
             --set operator.syncPeriod=30s \
             --set controllers.agentPool.workers=5 \
             --set controllers.module.workers=5 \
@@ -87,9 +88,9 @@ jobs:
       - name: Run end-to-end test suite
         run: make test
         env:
-          TFC_OAUTH_TOKEN: ${{ secrets.TFC_OAUTH_TOKEN }}
-          TFC_ORG: ${{ secrets.TFC_ORG }}
-          TFC_TOKEN: ${{ secrets.TFC_TOKEN }}
-          TFC_VCS_REPO: ${{ secrets.TFC_VCS_REPO }}
-          TFE_ADDRESS: ${{ secrets.TFE_ADDRESS }}
+          TFC_OAUTH_TOKEN: ${{ secrets.TFE_OAUTH_TOKEN }}
+          TFC_ORG: ${{ secrets.TFE_ORG }}
+          TFC_TOKEN: ${{ secrets.TFE_TOKEN }}
+          TFC_VCS_REPO: ${{ secrets.TFE_VCS_REPO }}
           TFC_TLS_SKIP_VERIFY: true
+          TFE_ADDRESS: ${{ secrets.TFE_ADDRESS }}

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,4 +1,4 @@
-name: API tests
+name: Unit tests
 
 on:
   schedule:
@@ -25,5 +25,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Run API tests
-        run: make test-api
+      - name: Run Unit tests
+        run: |
+          make test-api
+          make test-utils

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -28,4 +28,4 @@ jobs:
       - name: Run Unit tests
         run: |
           make test-api
-          make test-utils
+          make test-internal

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+COPY internal/ internal/
 
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -trimpath -o $BIN_NAME main.go
 

--- a/Makefile
+++ b/Makefile
@@ -185,8 +185,8 @@ HASHICORP_COPYWRITE ?= $(LOCALBIN)/copywrite
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.0.1
 CONTROLLER_TOOLS_VERSION ?= v0.11.3
-CRD_REF_DOCS_VERSION ?= v0.0.8
-HASHICORP_COPYWRITE_VERSION ?= 0.16.3
+CRD_REF_DOCS_VERSION ?= v0.0.9
+HASHICORP_COPYWRITE_VERSION ?= 0.16.4
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,10 @@ test: manifests generate fmt vet copywrite envtest ## Run tests.
 test-api: fmt vet copywrite ## Run API tests.
 	go test -timeout 30m -count 1 -v ./api/v1alpha2
 
+.PHONY: test-internal
+test-internal: fmt vet copywrite ## Run internal/* tests.
+	go test -timeout 30m -count 1 -v ./internal/*
+
 ##@ Build
 
 .PHONY: build

--- a/api/v1alpha2/agentpool_validation_test.go
+++ b/api/v1alpha2/agentpool_validation_test.go
@@ -5,6 +5,8 @@ package v1alpha2
 
 import (
 	"testing"
+
+	"github.com/hashicorp/terraform-cloud-operator/internal/pointer"
 )
 
 func TestValidateAgentPoolSpecAgentToken(t *testing.T) {
@@ -56,7 +58,7 @@ func TestValidateAgentPoolSpecAgentToken(t *testing.T) {
 				AgentTokens: []*AgentToken{
 					{
 						Name:      "this",
-						CreatedAt: PointerOf(int64(1984)),
+						CreatedAt: pointer.PointerOf(int64(1984)),
 					},
 				},
 			},
@@ -66,7 +68,7 @@ func TestValidateAgentPoolSpecAgentToken(t *testing.T) {
 				AgentTokens: []*AgentToken{
 					{
 						Name:       "this",
-						LastUsedAt: PointerOf(int64(1984)),
+						LastUsedAt: pointer.PointerOf(int64(1984)),
 					},
 				},
 			},

--- a/controllers/agentpool_controller_autoscaling.go
+++ b/controllers/agentpool_controller_autoscaling.go
@@ -14,9 +14,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
 
 	appv1alpha2 "github.com/hashicorp/terraform-cloud-operator/api/v1alpha2"
+	"github.com/hashicorp/terraform-cloud-operator/internal/pointer"
 )
 
 func getWorkspaceQueueDepth(ctx context.Context, ap *agentPoolInstance, workspaceID string) (int, error) {
@@ -135,7 +135,7 @@ func (r *AgentPoolReconciler) reconcileAgentAutoscaling(ctx context.Context, ap 
 	} else if (int(*currentReplicas) + queueDepth) > int(*ap.instance.Spec.AgentDeploymentAutoscaling.MaxReplicas) {
 		desiredReplicas = ap.instance.Spec.AgentDeploymentAutoscaling.MaxReplicas
 	} else if queueDepth > int(*currentReplicas) {
-		desiredReplicas = pointer.Int32(int32(int(*currentReplicas) + queueDepth))
+		desiredReplicas = pointer.PointerOf(int32(int(*currentReplicas) + queueDepth))
 	}
 
 	if *desiredReplicas != *currentReplicas {

--- a/controllers/agentpool_controller_deployment.go
+++ b/controllers/agentpool_controller_deployment.go
@@ -10,13 +10,13 @@ import (
 
 	tfc "github.com/hashicorp/go-tfe"
 	appv1alpha2 "github.com/hashicorp/terraform-cloud-operator/api/v1alpha2"
+	"github.com/hashicorp/terraform-cloud-operator/internal/pointer"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -121,7 +121,7 @@ func (r *AgentPoolReconciler) deleteDeployment(ctx context.Context, ap *agentPoo
 }
 
 func agentPoolDeployment(ap *agentPoolInstance) *appsv1.Deployment {
-	var r *int32 = pointer.Int32(1) // default to one replica if not otherwise configured
+	var r *int32 = pointer.PointerOf(int32(1)) // default to one replica if not otherwise configured
 	if ap.instance.Spec.AgentDeployment.Replicas != nil {
 		r = ap.instance.Spec.AgentDeployment.Replicas
 	}
@@ -159,7 +159,7 @@ func agentPoolDeployment(ap *agentPoolInstance) *appsv1.Deployment {
 				RollingUpdate: &appsv1.RollingUpdateDeployment{
 					// this is important to ensure the number of pods does not temporarily
 					// shoot over the max agents allowed when rolling the deployment.
-					MaxSurge: appv1alpha2.PointerOf(intstr.FromInt(0)),
+					MaxSurge: pointer.PointerOf(intstr.FromInt(0)),
 				},
 			},
 			Template: corev1.PodTemplateSpec{

--- a/controllers/agentpool_controller_test.go
+++ b/controllers/agentpool_controller_test.go
@@ -19,6 +19,7 @@ import (
 
 	tfc "github.com/hashicorp/go-tfe"
 	appv1alpha2 "github.com/hashicorp/terraform-cloud-operator/api/v1alpha2"
+	"github.com/hashicorp/terraform-cloud-operator/internal/pointer"
 )
 
 var _ = Describe("Agent Pool controller", Ordered, func() {
@@ -284,7 +285,7 @@ var _ = Describe("Agent Pool controller", Ordered, func() {
 
 			// ADD EMPTY AgentDeployment BLOCK
 			instance.Spec.AgentDeployment = &appv1alpha2.AgentDeployment{
-				Replicas: appv1alpha2.PointerOf(int32(3)),
+				Replicas: pointer.PointerOf(int32(3)),
 			}
 			Expect(k8sClient.Update(ctx, instance)).Should(Succeed())
 
@@ -372,9 +373,9 @@ var _ = Describe("Agent Pool controller", Ordered, func() {
 				TargetWorkspaces: []appv1alpha2.TargetWorkspace{
 					{Name: "test-workspace"},
 				},
-				MinReplicas:           appv1alpha2.PointerOf(int32(3)),
-				MaxReplicas:           appv1alpha2.PointerOf(int32(5)),
-				CooldownPeriodSeconds: appv1alpha2.PointerOf(int32(60)),
+				MinReplicas:           pointer.PointerOf(int32(3)),
+				MaxReplicas:           pointer.PointerOf(int32(5)),
+				CooldownPeriodSeconds: pointer.PointerOf(int32(60)),
 			}
 			Expect(k8sClient.Update(ctx, instance)).Should(Succeed())
 
@@ -386,9 +387,9 @@ var _ = Describe("Agent Pool controller", Ordered, func() {
 			Expect(instance.Spec.AgentDeploymentAutoscaling.TargetWorkspaces).To(Equal([]appv1alpha2.TargetWorkspace{
 				{Name: "test-workspace"},
 			}))
-			Expect(instance.Spec.AgentDeploymentAutoscaling.MinReplicas).To(Equal(appv1alpha2.PointerOf(int32(3))))
-			Expect(instance.Spec.AgentDeploymentAutoscaling.MaxReplicas).To(Equal(appv1alpha2.PointerOf(int32(5))))
-			Expect(instance.Spec.AgentDeploymentAutoscaling.CooldownPeriodSeconds).To(Equal(appv1alpha2.PointerOf(int32(60))))
+			Expect(instance.Spec.AgentDeploymentAutoscaling.MinReplicas).To(Equal(pointer.PointerOf(int32(3))))
+			Expect(instance.Spec.AgentDeploymentAutoscaling.MaxReplicas).To(Equal(pointer.PointerOf(int32(5))))
+			Expect(instance.Spec.AgentDeploymentAutoscaling.CooldownPeriodSeconds).To(Equal(pointer.PointerOf(int32(60))))
 		})
 	})
 })

--- a/controllers/agentpool_controller_tokens.go
+++ b/controllers/agentpool_controller_tokens.go
@@ -9,6 +9,7 @@ import (
 
 	tfc "github.com/hashicorp/go-tfe"
 	appv1alpha2 "github.com/hashicorp/terraform-cloud-operator/api/v1alpha2"
+	"github.com/hashicorp/terraform-cloud-operator/internal/pointer"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,8 +106,8 @@ func (r *AgentPoolReconciler) createAgentPoolTokens(ctx context.Context, ap *age
 		ap.instance.Status.AgentTokens = append(ap.instance.Status.AgentTokens, &appv1alpha2.AgentToken{
 			Name:       at.Description,
 			ID:         at.ID,
-			CreatedAt:  appv1alpha2.PointerOf(at.CreatedAt.Unix()),
-			LastUsedAt: appv1alpha2.PointerOf(at.LastUsedAt.Unix()),
+			CreatedAt:  pointer.PointerOf(at.CreatedAt.Unix()),
+			LastUsedAt: pointer.PointerOf(at.LastUsedAt.Unix()),
 		})
 		ap.log.Info("Reconcile Agent Tokens", "msg", fmt.Sprintf("successfully created a new agent token %q %q", t, at.ID))
 		// UPDATE SECRET

--- a/controllers/module_controller_test.go
+++ b/controllers/module_controller_test.go
@@ -57,23 +57,19 @@ var _ = Describe("Module controller", Ordered, func() {
 					},
 				},
 				Module: &appv1alpha2.ModuleSource{
-					Source:  "github.com/arybolovlev/terraform-provider-module-random",
-					Version: "0.0.4",
+					Source:  "hashicorp/animal/demo",
+					Version: "1.0.0",
 				},
 				DestroyOnDeletion: true,
 				Variables: []appv1alpha2.ModuleVariable{
 					{
-						Name: "string_length",
+						Name: "name",
 					},
 				},
 				Outputs: []appv1alpha2.ModuleOutput{
 					{
-						Name:      "bool",
+						Name:      "animal",
 						Sensitive: false,
-					},
-					{
-						Name:      "secret",
-						Sensitive: true,
 					},
 				},
 			},
@@ -90,9 +86,12 @@ var _ = Describe("Module controller", Ordered, func() {
 			return errors.IsNotFound(err)
 		}).Should(BeTrue())
 
-		// Delete workspace
-		err := tfClient.Workspaces.Delete(ctx, organization, workspace)
-		Expect(err).Should(Succeed())
+		// Make sure that the Terraform Cloud workspace is deleted
+		Eventually(func() bool {
+			err := tfClient.Workspaces.Delete(ctx, organization, workspace)
+			// The Terraform Cloud client will return the error 'ResourceNotFound' once the workspace does not exist
+			return err == tfc.ErrResourceNotFound || err == nil
+		}).Should(BeTrue())
 	})
 
 	Context("Module controller", func() {
@@ -107,9 +106,9 @@ var _ = Describe("Module controller", Ordered, func() {
 
 			// Create TFC Workspace variables
 			_, err = tfClient.Variables.Create(ctx, ws.ID, tfc.VariableCreateOptions{
-				Key:      tfc.String("string_length"),
-				Value:    tfc.String("512"),
-				HCL:      tfc.Bool(true),
+				Key:      tfc.String("name"),
+				Value:    tfc.String("Pluto"),
+				HCL:      tfc.Bool(false),
 				Category: tfc.Category(tfc.CategoryTerraform),
 			})
 			Expect(err).Should(Succeed())
@@ -159,9 +158,9 @@ var _ = Describe("Module controller", Ordered, func() {
 
 			// Create TFC Workspace variables
 			_, err = tfClient.Variables.Create(ctx, ws.ID, tfc.VariableCreateOptions{
-				Key:      tfc.String("string_length"),
-				Value:    tfc.String("512"),
-				HCL:      tfc.Bool(true),
+				Key:      tfc.String("name"),
+				Value:    tfc.String("Pluto"),
+				HCL:      tfc.Bool(false),
 				Category: tfc.Category(tfc.CategoryTerraform),
 			})
 			Expect(err).Should(Succeed())

--- a/controllers/workspace_controller_notifications.go
+++ b/controllers/workspace_controller_notifications.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	tfc "github.com/hashicorp/go-tfe"
 
-	appv1alpha2 "github.com/hashicorp/terraform-cloud-operator/api/v1alpha2"
+	"github.com/hashicorp/terraform-cloud-operator/internal/slice"
 )
 
 func hasNotificationItem(s []tfc.NotificationConfiguration, f tfc.NotificationConfiguration) (int, bool) {
@@ -34,7 +34,7 @@ func notificationsDifference(a, b []tfc.NotificationConfiguration) []tfc.Notific
 	for _, av := range a {
 		i, t := hasNotificationItem(bc, av)
 		if t {
-			bc = appv1alpha2.RemoveFromSlice(bc, i)
+			bc = slice.RemoveFromSlice(bc, i)
 		} else {
 			d = append(d, av)
 		}

--- a/internal/pointer/pointer.go
+++ b/internal/pointer/pointer.go
@@ -1,0 +1,8 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package pointer
+
+func PointerOf[A any](a A) *A {
+	return &a
+}

--- a/internal/pointer/pointer_test.go
+++ b/internal/pointer/pointer_test.go
@@ -1,10 +1,9 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package v1alpha2
+package pointer
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -25,22 +24,5 @@ func TestPointerOf(t *testing.T) {
 	i64p := PointerOf(i64)
 	if i64 != *i64p {
 		t.Error("Failed to get int64 pointer")
-	}
-}
-
-func TestRemoveFromSlice(t *testing.T) {
-	input := [][]any{
-		{1, 2, 3},
-		{"a", "b", "c"},
-	}
-	want := [][]any{
-		{1, 3},
-		{"a", "c"},
-	}
-	for i, s := range input {
-		r := RemoveFromSlice(s, 1)
-		if !reflect.DeepEqual(want[i], r) {
-			t.Errorf("Failed to remove an element from slice %d", i)
-		}
 	}
 }

--- a/internal/slice/slice.go
+++ b/internal/slice/slice.go
@@ -1,11 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-package v1alpha2
-
-func PointerOf[A any](a A) *A {
-	return &a
-}
+package slice
 
 func RemoveFromSlice[A any](slice []A, i int) []A {
 	return append(slice[:i], slice[i+1:]...)

--- a/internal/slice/slice_test.go
+++ b/internal/slice/slice_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package slice
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestRemoveFromSlice(t *testing.T) {
+	input := [][]any{
+		{1, 2, 3},
+		{"a", "b", "c"},
+	}
+	want := [][]any{
+		{1, 3},
+		{"a", "c"},
+	}
+	for i, s := range input {
+		r := RemoveFromSlice(s, 1)
+		if !reflect.DeepEqual(want[i], r) {
+			t.Errorf("Failed to remove an element from slice %d", i)
+		}
+	}
+}


### PR DESCRIPTION
### Description

Move genetic helper functions to `internal/`.

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
