### PR TITLE
serviceaccount enable,name variables

### DIFF
--- a/charts/terraform-cloud-operator/templates/_helpers.tpl
+++ b/charts/terraform-cloud-operator/templates/_helpers.tpl
@@ -55,8 +55,8 @@ Create the name of the service account to use
 */}}
 {{- define "terraform-cloud-operator.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "terraform-cloud-operator.fullname" .) .Values.serviceAccount.name }}
+{{- default (printf "%s-%s" .Release.Name "controller-manager") .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.serviceAccount.name -}}
 {{- end }}
 {{- end }}

--- a/charts/terraform-cloud-operator/templates/clusterrolebinding.yaml
+++ b/charts/terraform-cloud-operator/templates/clusterrolebinding.yaml
@@ -11,7 +11,7 @@ roleRef:
   name: {{ .Release.Name }}-manager-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}-controller-manager
+  name: {{ include "terraform-cloud-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -24,5 +24,5 @@ roleRef:
   name: {{ .Release.Name }}-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}-controller-manager
+  name: {{ include "terraform-cloud-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/terraform-cloud-operator/templates/deployment.yaml
+++ b/charts/terraform-cloud-operator/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
               memory: 64Mi
           securityContext:
             allowPrivilegeEscalation: false
-      serviceAccountName: {{ .Release.Name }}-controller-manager
+      serviceAccountName: {{ include "terraform-cloud-operator.serviceAccountName" . }}
       securityContext:
         runAsNonRoot: true
       terminationGracePeriodSeconds: 10

--- a/charts/terraform-cloud-operator/templates/rolebinding.yaml
+++ b/charts/terraform-cloud-operator/templates/rolebinding.yaml
@@ -12,5 +12,5 @@ roleRef:
   name: {{ .Release.Name }}-leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: {{ .Release.Name }}-controller-manager
+  name: {{ include "terraform-cloud-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/terraform-cloud-operator/templates/serviceaccount.yaml
+++ b/charts/terraform-cloud-operator/templates/serviceaccount.yaml
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
-
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-controller-manager
+  name: {{ include "terraform-cloud-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -46,3 +46,7 @@ controllers:
 # Custom Certificate Authority bundle to validate API TLS certificates
 # Expects a path to a CRT file containing concatenated certificates
 customCAcertificates: ""
+
+serviceAccount:
+  create: true
+  name:


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

### Description
<!---
--->
Current the _helpers.tpl contains service account name template but it not in use.
Now using the template with default to the existing value (backward compatible),
As well  the template supports of enable for creation of the service account, I added support for this flag (backward compatible).

### Usage Example
<!---
--->
```
#values.yml

#override the service account name:
serviceAccount:
  create: true
  name: my-serviceaccount
  
#supply already exists service account:
serviceAccount:
  create: false
  name: my-existing-serviceaccount
  
#keep the default service account name:
serviceAccount:
  create: true
```


### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):
<!--
-->

```release-note
Service account enable, name values support 
```

### References
<!---
Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
N/A
-->

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
