### PR TITLE
🤖 Bump `kube-rbac-proxy` to `0.14.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ DEPENDENCIES:
 * Bump `k8s.io/apimachinery` from 0.27.3 to 0.27.4. [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)]
 * Bump `k8s.io/client-go` from 0.27.3 to 0.27.4. [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)]
 * Bump `sigs.k8s.io/controller-runtime` from 0.15.0 to 0.15.1. [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)]
+* Bump `kube-rbac-proxy` image from `0.13.1` to `0.14.2`. [[GH-251](https://github.com/hashicorp/terraform-cloud-operator/pull/251)]
 
 ## 2.0.0-beta7 (July 07, 2023)
 

--- a/charts/terraform-cloud-operator/templates/deployment.yaml
+++ b/charts/terraform-cloud-operator/templates/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             readOnly: true
 {{- end }}
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+          image: quay.io/brancz/kube-rbac-proxy:v0.14.2
           imagePullPolicy: IfNotPresent
           args:
           - --secure-listen-address=0.0.0.0:8443


### PR DESCRIPTION
### Description

Bump `kube-rbac-proxy` image from `0.13.1` to `0.14.2`.

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
Bump `kube-rbac-proxy` image from `0.13.1` to `0.14.2`.
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
