### PR TITLE
🚀 Add the ability to configure `kube-rbac-proxy` image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ DEPENDENCIES:
 * Bump `k8s.io/api` from 0.27.5 to 0.27.6. [[GH-264](https://github.com/hashicorp/terraform-cloud-operator/pull/264)]
 * Bump `k8s.io/apimachinery` from 0.27.5 to 0.27.6. [[GH-264](https://github.com/hashicorp/terraform-cloud-operator/pull/264)]
 * Bump `k8s.io/client-go` from 0.27.5 to 0.27.6. [[GH-264](https://github.com/hashicorp/terraform-cloud-operator/pull/264)]
+* Bump `kube-rbac-proxy` image from `0.14.2` to `0.14.3`. [[GH-271](https://github.com/hashicorp/terraform-cloud-operator/pull/271)]
 * Bump `golang.org/x/net` from 0.14.0 to 0.17.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]
 * Bump `golang.org/x/sys` from 0.11.0 to 0.13.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]
 * Bump `golang.org/x/term` from 0.11.0 to 0.13.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## 2.0.0 (UNRELEASED)
 
+ENHANCEMENT:
+
+* `Helm Chart`: Add the ability to configure `kube-rbac-proxy` image and resources. [[GH-259](https://github.com/hashicorp/terraform-cloud-operator/pull/259)] [[GH-271](https://github.com/hashicorp/terraform-cloud-operator/pull/271)]
+
+DOCS:
+
+* Update FAQ. [[GH-271](https://github.com/hashicorp/terraform-cloud-operator/pull/271)]
+
 DEPENDENCIES:
 
 * Bump `sigs.k8s.io/controller-runtime` from 0.15.1 to 0.15.2. [[GH-258](https://github.com/hashicorp/terraform-cloud-operator/pull/258)]
@@ -12,6 +20,10 @@ DEPENDENCIES:
 * Bump `golang.org/x/term` from 0.11.0 to 0.13.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]
 * Bump `golang.org/x/text` from 0.12.0 to 0.13.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]
 * Bump `github.com/hashicorp/go-tfe` from 1.32.1 to 1.35.0. [[GH-273](https://github.com/hashicorp/terraform-cloud-operator/pull/273)]
+
+## Community Contributors :raised_hands:
+- @kieranbrown made their contribution in https://github.com/hashicorp/terraform-cloud-operator/pull/259
+- @KamalAman for constantly providing us with a valuable feedback :rocket:
 
 ## 2.0.0-beta8 (August 29, 2023)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ There are two main pieces of the Operator `API` and `Controller`. Depending on w
     
 - Controllers:
 
-    We rely on (Ginkgo)[https://github.com/onsi/ginkgo] testing framework in our controllers E2E tests. If your made controller-related changes(/controllers/**), please make sure you have updated the tests and always run them.
+    We rely on [Ginkgo](https://github.com/onsi/ginkgo) testing framework in our controllers E2E tests. If your made controller-related changes(/controllers/**), please make sure you have updated the tests and always run them.
 
     Export the organization name and API token to environment variable:
 

--- a/charts/terraform-cloud-operator/README.md
+++ b/charts/terraform-cloud-operator/README.md
@@ -96,6 +96,13 @@ In the above example, the Operator will watch all namespaces in the Kubernetes c
 | operator.watchedNamespaces | list | [] | List of namespaces the controllers should watch. |
 | operator.tfeAddress | string | "" | The API URL of a Terraform Enterprise instance. |
 | operator.skipTLSVerify | bool | false | Whether or not to ignore TLS certification warnings. |
+| kubeRbacProxy.image.repository | string | "quay.io/brancz/kube-rbac-proxy" | Image repository. |
+| kubeRbacProxy.image.pullPolicy | string | "IfNotPresent" | Image pull policy. |
+| kubeRbacProxy.image.tag | string | "v0.14.3" | Image tag. |
+| kubeRbacProxy.resources.limits.cpu | string | "500m" | Limits as a maximum amount of CPU to be used by a container. |
+| kubeRbacProxy.resources.limits.memory | string | "128Mi" | Limits as a maximum amount of memory to be used by a container. |
+| kubeRbacProxy.resources.requests.cpu | string | "50m" | Guaranteed minimum amount of CPU to be used by a container. |
+| kubeRbacProxy.resources.requests.memory | string | "64Mi" | Guaranteed minimum amount of memory to be used by a container. |
 | controllers.agentPool.workers | int | 1 | The number of the Agent Pool controller workers. |
 | controllers.module.workers | int | 1 | The number of the Module controller workers. |
 | controllers.workspace.workers | int | 1 | The number of the Workspace controller workers. |

--- a/charts/terraform-cloud-operator/templates/deployment.yaml
+++ b/charts/terraform-cloud-operator/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
         - name: manager
-          image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}"
+          image: {{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
           args:
           - --sync-period={{ .Values.operator.syncPeriod }}
@@ -66,15 +66,15 @@ spec:
           securityContext:
             allowPrivilegeEscalation: false
           volumeMounts:
-{{- if .Values.customCAcertificates }}
+          {{- if .Values.customCAcertificates }}
           - name: ca-certificates
             mountPath: /etc/ssl/certs/custom-ca-certificates.crt
             subPath: ca-certificates
             readOnly: true
-{{- end }}
+          {{- end }}
         - name: kube-rbac-proxy
-          image: quay.io/brancz/kube-rbac-proxy:v0.14.2
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag }}
+          imagePullPolicy: {{ .Values.kubeRbacProxy.image.pullPolicy }}
           args:
           - --secure-listen-address=0.0.0.0:8443
           - --upstream=http://127.0.0.1:8080/

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -32,6 +32,10 @@ operator:
   skipTLSVerify: false
 
 kubeRbacProxy:
+  image:
+    repository: quay.io/brancz/kube-rbac-proxy
+    pullPolicy: IfNotPresent
+    tag: v0.14.2
   resources:
     limits:
       cpu: 500m

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -35,7 +35,8 @@ kubeRbacProxy:
   image:
     repository: quay.io/brancz/kube-rbac-proxy
     pullPolicy: IfNotPresent
-    tag: v0.14.2
+    tag: v0.14.3
+
   resources:
     limits:
       cpu: 500m

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -88,7 +88,7 @@
 
 - **What does `kube-rbac-proxy` do?**
 
-  The `kube-rbac-proxy` is a small HTTP proxy for a single upstream, that can perform RBAC authorization against the Kubernetes API. More information is in the author's [blog post](https://www.brancz.com/2018/02/27/using-kube-rbac-proxy-to-secure-kubernetes-workloads/).
+  The `kube-rbac-proxy` is a small HTTP proxy for a single upstream, that can perform RBAC authorization against the Kubernetes API. This allows providing RBAC-based access to the operator [metrics](./metrics.md) within the Kubernetes cluster. More information is in the author's [blog post](https://www.brancz.com/2018/02/27/using-kube-rbac-proxy-to-secure-kubernetes-workloads/).
 
 ## Performance
 


### PR DESCRIPTION
### Description

Add the ability to configure `kube-rbac-proxy` image.

Test results:

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/6483796673/job/17606187384 _TFC_
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/6483797661/job/17607789674 _TFC + Helm_
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/6483798887/job/17606193906 _TFE_
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/6483800064/job/17606196947 _TFE + Helm_

### Usage Example

```console
$ helm install ... --set kubeRbacProxy.image.tag=v0.14.3
```

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
ENHANCEMENT:

* `Helm Chart`: Add the ability to configure `kube-rbac-proxy` image.

DOCS:

* Update FAQ.

DEPENDENCIES:

* Bump `kube-rbac-proxy` image from `0.14.2` to `0.14.3`.
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
