### PR TITLE
Bump `kube-rbac-proxy` image from 0.14.3 to 0.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ DEPENDENCIES:
 * Bump `k8s.io/api` from 0.27.5 to 0.27.6. [[GH-264](https://github.com/hashicorp/terraform-cloud-operator/pull/264)]
 * Bump `k8s.io/apimachinery` from 0.27.5 to 0.27.6. [[GH-264](https://github.com/hashicorp/terraform-cloud-operator/pull/264)]
 * Bump `k8s.io/client-go` from 0.27.5 to 0.27.6. [[GH-264](https://github.com/hashicorp/terraform-cloud-operator/pull/264)]
-* Bump `kube-rbac-proxy` image from `0.14.2` to `0.14.3`. [[GH-271](https://github.com/hashicorp/terraform-cloud-operator/pull/271)]
+* Bump `kube-rbac-proxy` image from `0.14.2` to `0.14.4`. [[GH-271](https://github.com/hashicorp/terraform-cloud-operator/pull/271)] [[GH-281](https://github.com/hashicorp/terraform-cloud-operator/pull/281)]
 * Bump `golang.org/x/net` from 0.14.0 to 0.17.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]
 * Bump `golang.org/x/sys` from 0.11.0 to 0.13.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]
 * Bump `golang.org/x/term` from 0.11.0 to 0.13.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]

--- a/charts/terraform-cloud-operator/README.md
+++ b/charts/terraform-cloud-operator/README.md
@@ -98,7 +98,7 @@ In the above example, the Operator will watch all namespaces in the Kubernetes c
 | operator.skipTLSVerify | bool | false | Whether or not to ignore TLS certification warnings. |
 | kubeRbacProxy.image.repository | string | "quay.io/brancz/kube-rbac-proxy" | Image repository. |
 | kubeRbacProxy.image.pullPolicy | string | "IfNotPresent" | Image pull policy. |
-| kubeRbacProxy.image.tag | string | "v0.14.3" | Image tag. |
+| kubeRbacProxy.image.tag | string | "v0.14.4" | Image tag. |
 | kubeRbacProxy.resources.limits.cpu | string | "500m" | Limits as a maximum amount of CPU to be used by a container. |
 | kubeRbacProxy.resources.limits.memory | string | "128Mi" | Limits as a maximum amount of memory to be used by a container. |
 | kubeRbacProxy.resources.requests.cpu | string | "50m" | Guaranteed minimum amount of CPU to be used by a container. |

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -35,7 +35,7 @@ kubeRbacProxy:
   image:
     repository: quay.io/brancz/kube-rbac-proxy
     pullPolicy: IfNotPresent
-    tag: v0.14.3
+    tag: v0.14.4
 
   resources:
     limits:


### PR DESCRIPTION
### Description

Bump `kube-rbac-proxy` image from 0.14.3 to 0.14.4 that contains Go packages security fixes.

E2E test results: https://github.com/hashicorp/terraform-cloud-operator/actions/runs/6545249283/job/17773333414

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
