### PR TITLE
🐛 Fix output synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 2.0.0 (UNRELEASED)
 
+BUG FIXES:
+
+* `Workspace`: fix an issue of properly handling special characters when generating string output. [[GH-289](https://github.com/hashicorp/terraform-cloud-operator/pull/289)]
+* `Module`: fix an issue of properly handling special characters when generating string output. [[GH-289](https://github.com/hashicorp/terraform-cloud-operator/pull/289)]
+
 ENHANCEMENT:
 
 * `Helm Chart`: Add the ability to configure `kube-rbac-proxy` image and resources. [[GH-259](https://github.com/hashicorp/terraform-cloud-operator/pull/259)] [[GH-271](https://github.com/hashicorp/terraform-cloud-operator/pull/271)]

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -25,6 +25,13 @@ func requeueOnErr(err error) (reconcile.Result, error) {
 	return reconcile.Result{}, err
 }
 
+// formatOutput formats TFC/E output to a string or bytes to save it further in
+// Kubernetes ConfigMap or Secret, respectively.
+//
+// Terraform supports the following types:
+// - https://developer.hashicorp.com/terraform/language/expressions/types
+// When the output value is `null`(special value), TFC/E does not return it.
+// Thus, we do not catch it here.
 func formatOutput(o *tfc.StateVersionOutput) (string, error) {
 	switch x := o.Value.(type) {
 	case bool:

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -4,8 +4,12 @@
 package controllers
 
 import (
+	"encoding/json"
+	"fmt"
+	"strconv"
 	"time"
 
+	tfc "github.com/hashicorp/go-tfe"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -19,4 +23,21 @@ func requeueAfter(duration time.Duration) (reconcile.Result, error) {
 
 func requeueOnErr(err error) (reconcile.Result, error) {
 	return reconcile.Result{}, err
+}
+
+func formatOutput(o *tfc.StateVersionOutput) (string, error) {
+	switch x := o.Value.(type) {
+	case bool:
+		return strconv.FormatBool(x), nil
+	case float64:
+		return fmt.Sprint(x), nil
+	case string:
+		return x, nil
+	default:
+		b, err := json.Marshal(o.Value)
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
 }

--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	tfc "github.com/hashicorp/go-tfe"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -30,6 +31,75 @@ var _ = Describe("Helpers", func() {
 			result, err := requeueOnErr(fmt.Errorf(""))
 			Expect(result).To(BeEquivalentTo(reconcile.Result{}))
 			Expect(err).ToNot(BeNil())
+		})
+	})
+
+	Context("FormatOutput", func() {
+		It("bool", func() {
+			o := &tfc.StateVersionOutput{
+				Type:  "boolean",
+				Value: true,
+			}
+			e := "true"
+			result, err := formatOutput(o)
+			Expect(result).To(BeEquivalentTo(e))
+			Expect(err).To(BeNil())
+		})
+		It("string", func() {
+			o := &tfc.StateVersionOutput{
+				Type:  "string",
+				Value: "hello",
+			}
+			e := "hello"
+			result, err := formatOutput(o)
+			Expect(result).To(BeEquivalentTo(e))
+			Expect(err).To(BeNil())
+		})
+		It("multilineString", func() {
+			o := &tfc.StateVersionOutput{
+				Type:  "string",
+				Value: "hello\nworld",
+			}
+			e := "hello\nworld"
+			result, err := formatOutput(o)
+			Expect(result).To(BeEquivalentTo(e))
+			Expect(err).To(BeNil())
+		})
+		It("number", func() {
+			o := &tfc.StateVersionOutput{
+				Type:  "number",
+				Value: 162,
+			}
+			e := "162"
+			result, err := formatOutput(o)
+			Expect(result).To(BeEquivalentTo(e))
+			Expect(err).To(BeNil())
+		})
+		It("list", func() {
+			o := &tfc.StateVersionOutput{
+				Type: "array",
+				Value: []any{
+					"one",
+					2,
+				},
+			}
+			e := `["one",2]`
+			result, err := formatOutput(o)
+			Expect(result).To(BeEquivalentTo(e))
+			Expect(err).To(BeNil())
+		})
+		It("map", func() {
+			o := &tfc.StateVersionOutput{
+				Type: "array",
+				Value: map[string]string{
+					"one": "een",
+					"two": "twee",
+				},
+			}
+			e := `{"one":"een","two":"twee"}`
+			result, err := formatOutput(o)
+			Expect(result).To(BeEquivalentTo(e))
+			Expect(err).To(BeNil())
 		})
 	})
 })

--- a/controllers/module_controller_outputs.go
+++ b/controllers/module_controller_outputs.go
@@ -77,9 +77,6 @@ func (r *ModuleReconciler) setOutputs(ctx context.Context, m *moduleInstance) er
 	nonSensitiveOutput := make(map[string]string)
 	sensitiveOutput := make(map[string][]byte)
 	for _, o := range outputs.Items {
-		var out string
-		// Terraform supports the following types:
-		// - https://developer.hashicorp.com/terraform/language/expressions/types
 		out, err := formatOutput(o)
 		if err != nil {
 			m.log.Error(err, "Reconcile Module Outputs", "mgs", fmt.Sprintf("failed to marshal JSON for %q", o.Name))

--- a/controllers/module_controller_outputs.go
+++ b/controllers/module_controller_outputs.go
@@ -82,7 +82,7 @@ func (r *ModuleReconciler) setOutputs(ctx context.Context, m *moduleInstance) er
 	sensitiveOutput := make(map[string][]byte)
 	for _, o := range outputs.Items {
 		var out string
-		// The Terraform supports the following types:
+		// Terraform supports the following types:
 		// - https://developer.hashicorp.com/terraform/language/expressions/types
 		switch o.Type {
 		case "boolean":

--- a/controllers/module_controller_outputs.go
+++ b/controllers/module_controller_outputs.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -70,24 +71,39 @@ func (r *ModuleReconciler) setOutputs(ctx context.Context, m *moduleInstance) er
 		return fmt.Errorf("secret %s is in use by different object thus it cannot be used to store outputs", oName)
 	}
 
-	nonSensitiveOutput := make(map[string]string)
-	sensitiveOutput := make(map[string][]byte)
-
 	outputs, err := m.tfClient.Client.StateVersions.ListOutputs(ctx, workspace.CurrentStateVersion.ID, &tfc.StateVersionOutputsListOptions{})
 	if err != nil {
 		return err
 	}
+
+	// TODO:
+	// - make outputs sync more generic since it is used more than once(+Workspace)
+	nonSensitiveOutput := make(map[string]string)
+	sensitiveOutput := make(map[string][]byte)
 	for _, o := range outputs.Items {
-		bytes, err := json.Marshal(o.Value)
-		if err != nil {
-			m.log.Error(err, "Reconcile Module Outputs", "mgs", fmt.Sprintf("failed to marshal JSON for %q", o.Name))
-			r.Recorder.Event(&m.instance, corev1.EventTypeWarning, "ReconcileOutputs", "failed to marshal JSON")
-			continue
+		var out string
+		// The Terraform supports the following types:
+		// - https://developer.hashicorp.com/terraform/language/expressions/types
+		switch o.Type {
+		case "boolean":
+			out = strconv.FormatBool(o.Value.(bool))
+		case "number":
+			out = fmt.Sprint(o.Value.(float64))
+		case "string":
+			out = o.Value.(string)
+		default:
+			b, err := json.Marshal(o.Value)
+			if err != nil {
+				m.log.Error(err, "Reconcile Module Outputs", "mgs", fmt.Sprintf("failed to marshal JSON for %q", o.Name))
+				r.Recorder.Event(&m.instance, corev1.EventTypeWarning, "ReconcileOutputs", "failed to marshal JSON")
+				continue
+			}
+			out = string(b)
 		}
 		if o.Sensitive {
-			sensitiveOutput[o.Name] = trimDoubleQuotes(bytes)
+			sensitiveOutput[o.Name] = []byte(out)
 		} else {
-			nonSensitiveOutput[o.Name] = string(trimDoubleQuotes(bytes))
+			nonSensitiveOutput[o.Name] = out
 		}
 	}
 

--- a/controllers/workspace_controller_outputs.go
+++ b/controllers/workspace_controller_outputs.go
@@ -5,9 +5,7 @@ package controllers
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -87,29 +85,17 @@ func (r *WorkspaceReconciler) setOutputs(ctx context.Context, w *workspaceInstan
 		return err
 	}
 
-	// TODO:
-	// - make outputs sync more generic since it is used more than once(+Module)
 	nonSensitiveOutput := make(map[string]string)
 	sensitiveOutput := make(map[string][]byte)
 	for _, o := range outputs.Items {
 		var out string
 		// Terraform supports the following types:
 		// - https://developer.hashicorp.com/terraform/language/expressions/types
-		switch o.Type {
-		case "boolean":
-			out = strconv.FormatBool(o.Value.(bool))
-		case "number":
-			out = fmt.Sprint(o.Value.(float64))
-		case "string":
-			out = o.Value.(string)
-		default:
-			b, err := json.Marshal(o.Value)
-			if err != nil {
-				w.log.Error(err, "Reconcile Module Outputs", "mgs", fmt.Sprintf("failed to marshal JSON for %q", o.Name))
-				r.Recorder.Event(&w.instance, corev1.EventTypeWarning, "ReconcileOutputs", "failed to marshal JSON")
-				continue
-			}
-			out = string(b)
+		out, err := formatOutput(o)
+		if err != nil {
+			w.log.Error(err, "Reconcile Module Outputs", "mgs", fmt.Sprintf("failed to marshal JSON for %q", o.Name))
+			r.Recorder.Event(&w.instance, corev1.EventTypeWarning, "ReconcileOutputs", "failed to marshal JSON")
+			continue
 		}
 		if o.Sensitive {
 			sensitiveOutput[o.Name] = []byte(out)

--- a/controllers/workspace_controller_outputs.go
+++ b/controllers/workspace_controller_outputs.go
@@ -88,9 +88,6 @@ func (r *WorkspaceReconciler) setOutputs(ctx context.Context, w *workspaceInstan
 	nonSensitiveOutput := make(map[string]string)
 	sensitiveOutput := make(map[string][]byte)
 	for _, o := range outputs.Items {
-		var out string
-		// Terraform supports the following types:
-		// - https://developer.hashicorp.com/terraform/language/expressions/types
 		out, err := formatOutput(o)
 		if err != nil {
 			w.log.Error(err, "Reconcile Module Outputs", "mgs", fmt.Sprintf("failed to marshal JSON for %q", o.Name))

--- a/controllers/workspace_controller_outputs.go
+++ b/controllers/workspace_controller_outputs.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -62,10 +62,6 @@ func (r *WorkspaceReconciler) secretAvailable(ctx context.Context, instance *app
 	return containsOwnerReference(o.GetOwnerReferences(), instance.UID)
 }
 
-func trimDoubleQuotes(bytes []byte) []byte {
-	return []byte(strings.Trim(string(bytes), `"`))
-}
-
 // func (r *WorkspaceReconciler) setOutputs(ctx context.Context, w *workspaceInstance, workspace *tfc.Workspace) error {
 func (r *WorkspaceReconciler) setOutputs(ctx context.Context, w *workspaceInstance) error {
 	workspace, err := w.tfClient.Client.Workspaces.ReadByID(ctx, w.instance.Status.WorkspaceID)
@@ -86,24 +82,39 @@ func (r *WorkspaceReconciler) setOutputs(ctx context.Context, w *workspaceInstan
 		return fmt.Errorf("secret %s is in use by different object thus it cannot be used to store outputs", oName)
 	}
 
-	nonSensitiveOutput := make(map[string]string)
-	sensitiveOutput := make(map[string][]byte)
-
 	outputs, err := w.tfClient.Client.StateVersions.ListOutputs(ctx, workspace.CurrentStateVersion.ID, &tfc.StateVersionOutputsListOptions{})
 	if err != nil {
 		return err
 	}
+
+	// TODO:
+	// - make outputs sync more generic since it is used more than once(+Module)
+	nonSensitiveOutput := make(map[string]string)
+	sensitiveOutput := make(map[string][]byte)
 	for _, o := range outputs.Items {
-		bytes, err := json.Marshal(o.Value)
-		if err != nil {
-			w.log.Error(err, "Reconcile Outputs", "mgs", fmt.Sprintf("failed to marshal JSON for %q", o.Name))
-			r.Recorder.Event(&w.instance, corev1.EventTypeWarning, "ReconcileOutputs", "failed to marshal JSON")
-			continue
+		var out string
+		// The Terraform supports the following types:
+		// - https://developer.hashicorp.com/terraform/language/expressions/types
+		switch o.Type {
+		case "boolean":
+			out = strconv.FormatBool(o.Value.(bool))
+		case "number":
+			out = fmt.Sprint(o.Value.(float64))
+		case "string":
+			out = o.Value.(string)
+		default:
+			b, err := json.Marshal(o.Value)
+			if err != nil {
+				w.log.Error(err, "Reconcile Module Outputs", "mgs", fmt.Sprintf("failed to marshal JSON for %q", o.Name))
+				r.Recorder.Event(&w.instance, corev1.EventTypeWarning, "ReconcileOutputs", "failed to marshal JSON")
+				continue
+			}
+			out = string(b)
 		}
 		if o.Sensitive {
-			sensitiveOutput[o.Name] = trimDoubleQuotes(bytes)
+			sensitiveOutput[o.Name] = []byte(out)
 		} else {
-			nonSensitiveOutput[o.Name] = string(trimDoubleQuotes(bytes))
+			nonSensitiveOutput[o.Name] = out
 		}
 	}
 

--- a/controllers/workspace_controller_outputs.go
+++ b/controllers/workspace_controller_outputs.go
@@ -93,7 +93,7 @@ func (r *WorkspaceReconciler) setOutputs(ctx context.Context, w *workspaceInstan
 	sensitiveOutput := make(map[string][]byte)
 	for _, o := range outputs.Items {
 		var out string
-		// The Terraform supports the following types:
+		// Terraform supports the following types:
 		// - https://developer.hashicorp.com/terraform/language/expressions/types
 		switch o.Type {
 		case "boolean":


### PR DESCRIPTION
### Description

Fix an issue of properly handling special characters when generating string output.

Terraform supports the following types:
- https://developer.hashicorp.com/terraform/language/expressions/types

This fix adds logic to handle `string`, `number`, and `bool` types as a string and separates them from `list`, `tuple`, `set`, `map`, and `object` that are treated as a JSON document.

HCL output example:

```hcl
output "multiline_string" {
  value     = <<EOT
hello
world
EOT
  sensitive = false
}
```

Before:

```yaml
---
apiVersion: v1
kind: ConfigMap
data:
  multiline_string: "hello\nworld"
...
```

After:

```yaml
---
apiVersion: v1
kind: ConfigMap
data:
  multiline_string: |
    hello
    world
...
```

Tests:

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/6667451265 **_TFC_**

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
* `Workspace`: fix an issue of properly handling special characters when generating string output.
* `Module`: fix an issue of properly handling special characters when generating string output.
```

### References

- Fix: https://github.com/hashicorp/terraform-cloud-operator/issues/284

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
