### PR TITLE
🔧 Tweak autoscaler logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ ENHANCEMENT:
 * `Helm Chart`: Add the ability to configure `kube-rbac-proxy` image and resources. [[GH-259](https://github.com/hashicorp/terraform-cloud-operator/pull/259)] [[GH-271](https://github.com/hashicorp/terraform-cloud-operator/pull/271)]
 * `AgentPool`: Add the ability to use wildcard-name searches to target workspaces for autoscaling. [[GH-274](https://github.com/hashicorp/terraform-cloud-operator/pull/274)]
 * `AgentPool`: Make `targetWorkspaces` field optional and default to targeting all workspaces linked to an AgentPool. [[GH-274](https://github.com/hashicorp/terraform-cloud-operator/pull/274)]
+* `AgentPool`: Tweak autoscaling to take into account Planning and Applying states when computing the replica count for agents  [[GH-290](https://github.com/hashicorp/terraform-cloud-operator/pull/290)]
+* `AgentPool`: Default agent pods to have a `terminationGracePeriod` of 15 minutes. [[GH-290](https://github.com/hashicorp/terraform-cloud-operator/pull/290)]
 
 DOCS:
 

--- a/controllers/agentpool_controller_autoscaling.go
+++ b/controllers/agentpool_controller_autoscaling.go
@@ -16,14 +16,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	appv1alpha2 "github.com/hashicorp/terraform-cloud-operator/api/v1alpha2"
-	"github.com/hashicorp/terraform-cloud-operator/internal/pointer"
 )
 
-func getWorkspaceQueueDepth(ctx context.Context, ap *agentPoolInstance, workspaceID string) (int, error) {
+func computeRequiredAgentsForWorkspace(ctx context.Context, ap *agentPoolInstance, workspaceID string) (int, error) {
 	statuses := []string{
-		string(tfc.RunPending),
 		string(tfc.RunPlanQueued),
 		string(tfc.RunApplyQueued),
+		string(tfc.RunApplying),
+		string(tfc.RunPlanning),
 	}
 	runs, err := ap.tfClient.Client.Runs.List(ctx, workspaceID, &tfc.RunListOptions{
 		Status: strings.Join(statuses, ","),
@@ -108,20 +108,29 @@ func getTargetWorkspaceIDsByWildcardName(ctx context.Context, ap *agentPoolInsta
 	return workspaceIDs, nil
 }
 
-func getQueueDepth(ctx context.Context, ap *agentPoolInstance) (int, error) {
-	depth := 0
+func computeRequiredAgents(ctx context.Context, ap *agentPoolInstance) (int32, error) {
+	required := 0
 	workspaceIDs, err := getTargetWorkspaceIDs(ctx, ap)
 	if err != nil {
 		return 0, err
 	}
-	for _, id := range workspaceIDs {
-		runs, err := getWorkspaceQueueDepth(ctx, ap, id)
+	for _, workspaceID := range workspaceIDs {
+		r, err := computeRequiredAgentsForWorkspace(ctx, ap, workspaceID)
 		if err != nil {
 			return 0, err
 		}
-		depth += runs
+		required += r
 	}
-	return depth, nil
+	return int32(required), nil
+}
+
+func computeDesiredReplicas(requiredAgents, minReplicas, maxReplicas int32) int32 {
+	if requiredAgents <= minReplicas {
+		return minReplicas
+	} else if requiredAgents >= maxReplicas {
+		return maxReplicas
+	}
+	return requiredAgents
 }
 
 func getAgentDeploymentNamespacedName(ap *agentPoolInstance) types.NamespacedName {
@@ -131,13 +140,13 @@ func getAgentDeploymentNamespacedName(ap *agentPoolInstance) types.NamespacedNam
 	}
 }
 
-func (r *AgentPoolReconciler) getAgentDeploymentReplicas(ctx context.Context, ap *agentPoolInstance) (*int32, error) {
+func (r *AgentPoolReconciler) getAgentDeploymentReplicas(ctx context.Context, ap *agentPoolInstance) (int32, error) {
 	deployment := appsv1.Deployment{}
 	err := r.Client.Get(ctx, getAgentDeploymentNamespacedName(ap), &deployment)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
-	return deployment.Spec.Replicas, nil
+	return *deployment.Spec.Replicas, nil
 }
 
 func (r *AgentPoolReconciler) scaleAgentDeployment(ctx context.Context, ap *agentPoolInstance, target *int32) error {
@@ -170,9 +179,9 @@ func (r *AgentPoolReconciler) reconcileAgentAutoscaling(ctx context.Context, ap 
 		}
 	}
 
-	queueDepth, err := getQueueDepth(ctx, ap)
+	requiredAgents, err := computeRequiredAgents(ctx, ap)
 	if err != nil {
-		ap.log.Error(err, "Reconcile Agent Autoscaling", "msg", "Failed to get pending runs")
+		ap.log.Error(err, "Reconcile Agent Autoscaling", "msg", "Failed to get agents needed")
 		r.Recorder.Eventf(&ap.instance, corev1.EventTypeWarning, "AutoscaleAgentPoolDeployment", "Autoscaling failed: %v", err.Error())
 		return err
 	}
@@ -184,27 +193,21 @@ func (r *AgentPoolReconciler) reconcileAgentAutoscaling(ctx context.Context, ap 
 		return err
 	}
 
-	desiredReplicas := currentReplicas
-	if queueDepth == 0 {
-		desiredReplicas = ap.instance.Spec.AgentDeploymentAutoscaling.MinReplicas
-	} else if (int(*currentReplicas) + queueDepth) > int(*ap.instance.Spec.AgentDeploymentAutoscaling.MaxReplicas) {
-		desiredReplicas = ap.instance.Spec.AgentDeploymentAutoscaling.MaxReplicas
-	} else if queueDepth > int(*currentReplicas) {
-		desiredReplicas = pointer.PointerOf(int32(int(*currentReplicas) + queueDepth))
-	}
-
-	if *desiredReplicas != *currentReplicas {
-		scalingEvent := fmt.Sprintf("Scaling agent deployment from %v to %v replicas", *currentReplicas, *desiredReplicas)
+	minReplicas := *ap.instance.Spec.AgentDeploymentAutoscaling.MinReplicas
+	maxReplicas := *ap.instance.Spec.AgentDeploymentAutoscaling.MaxReplicas
+	desiredReplicas := computeDesiredReplicas(requiredAgents, maxReplicas, minReplicas)
+	if desiredReplicas != currentReplicas {
+		scalingEvent := fmt.Sprintf("Scaling agent deployment from %v to %v replicas", currentReplicas, desiredReplicas)
 		ap.log.Info("Reconcile Agent Autoscaling", "msg", scalingEvent)
 		r.Recorder.Event(&ap.instance, corev1.EventTypeNormal, "AutoscaleAgentPoolDeployment", scalingEvent)
-		err := r.scaleAgentDeployment(ctx, ap, desiredReplicas)
+		err := r.scaleAgentDeployment(ctx, ap, &desiredReplicas)
 		if err != nil {
 			ap.log.Error(err, "Reconcile Agent Autoscaling", "msg", "Failed to scale agent deployment")
 			r.Recorder.Eventf(&ap.instance, corev1.EventTypeWarning, "AutoscaleAgentPoolDeployment", "Autoscaling failed: %v", err.Error())
 			return err
 		}
 		ap.instance.Status.AgentDeploymentAutoscalingStatus = &appv1alpha2.AgentDeploymentAutoscalingStatus{
-			DesiredReplicas: desiredReplicas,
+			DesiredReplicas: &desiredReplicas,
 			LastScalingEvent: &v1.Time{
 				Time: time.Now(),
 			},


### PR DESCRIPTION
This PR tweaks the logic in the AgentPool controller for autoscaling to take into account plans and applys that are already running when computing the replica count for the agent pool deployment. This PR also sets a default `terminationGracePeriod` on agent deployments to `900` seconds from the default of `30` to allow graceful shutdown of agents that are still busy. 

<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

### Description
<!---
Please describe your changes in detail.
--->

### Usage Example
<!---
Please provide a usage example if you have implemented a new feature.
--->

### Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):
<!--
Please write a release note message.
If the change is not user-facing, leave "NONE" in the release-note block below.
-->

```release-note
NONE
```

### References
<!---
Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
For example:
 - Fixes: GH-0000
-->

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
