### PR TITLE
🛠️ Migrate changelog management to Changie

### DIFF
--- a/.changes/2.2.0.md
+++ b/.changes/2.2.0.md
@@ -1,0 +1,199 @@
+## 2.2.0 (January 16, 2024)
+
+FEATURES:
+
+* `Project`: add a new controller `Project` that allows managing Terraform Cloud Projects. [[GH-309](https://github.com/hashicorp/terraform-cloud-operator/pull/309)].
+
+DEPENDENCIES:
+
+* Bump `k8s.io/api` from 0.27.7 to 0.27.8. [[GH-306](https://github.com/hashicorp/terraform-cloud-operator/pull/306)]
+* Bump `k8s.io/apimachinery` from 0.27.7 to 0.27.8. [[GH-306](https://github.com/hashicorp/terraform-cloud-operator/pull/306)]
+* Bump `k8s.io/client-go` from 0.27.7 to 0.27.8. [[GH-306](https://github.com/hashicorp/terraform-cloud-operator/pull/306)]
+* Bump `github.com/go-logr/zapr` from 1.2.4 to 1.3.0. [[GH-305](https://github.com/hashicorp/terraform-cloud-operator/pull/305)]
+* Bump `github.com/onsi/ginkgo/v2` from 2.13.0 to 2.13.2. [[GH-307](https://github.com/hashicorp/terraform-cloud-operator/pull/307)]
+* Bump `github.com/hashicorp/go-tfe` from 1.37.0 to 1.41.0. [[GH-316](https://github.com/hashicorp/terraform-cloud-operator/pull/316)]
+* Bump `github.com/hashicorp/go-slug` from 0.12.2 to 0.13.3. [[GH-316](https://github.com/hashicorp/terraform-cloud-operator/pull/316)]
+* Bump `github.com/go-logr/logr` from 1.3.0 to 1.4.1. [[GH-317](https://github.com/hashicorp/terraform-cloud-operator/pull/317)]
+* Bump `kube-rbac-proxy` image from 0.14.4 to 0.15.0. [[GH-320](https://github.com/hashicorp/terraform-cloud-operator/pull/320)]
+
+## 2.1.0 (November 27, 2023)
+
+ENHANCEMENT:
+
+* `Workspace`: Add the ability to configure the project for the workspace via a new field `spec.project.[id | name]`.  [[GH-300](https://github.com/hashicorp/terraform-cloud-operator/pull/300)]
+
+BUG FIXES:
+
+* `Module`: fix an issue when initiating foreground cascading deletion results in two destroy runs being triggered, and even after both runs are successfully executed, a module object persists in Kubernetes. [[GH-301](https://github.com/hashicorp/terraform-cloud-operator/pull/301)]
+
+## 2.0.0 (November 06, 2023)
+
+BUG FIXES:
+
+* `Workspace`: fix an issue of properly handling special characters when generating string output. [[GH-289](https://github.com/hashicorp/terraform-cloud-operator/pull/289)]
+* `Module`: fix an issue of properly handling special characters when generating string output. [[GH-289](https://github.com/hashicorp/terraform-cloud-operator/pull/289)]
+
+ENHANCEMENT:
+
+* `Helm Chart`: Add the ability to configure `kube-rbac-proxy` image and resources. [[GH-259](https://github.com/hashicorp/terraform-cloud-operator/pull/259)] [[GH-271](https://github.com/hashicorp/terraform-cloud-operator/pull/271)]
+* `AgentPool`: Add the ability to use wildcard-name searches to target workspaces for autoscaling. [[GH-274](https://github.com/hashicorp/terraform-cloud-operator/pull/274)]
+* `AgentPool`: Make `targetWorkspaces` field optional and default to targeting all workspaces linked to an AgentPool. [[GH-274](https://github.com/hashicorp/terraform-cloud-operator/pull/274)]
+* `AgentPool`: Tweak autoscaling to take into account Planning and Applying states when computing the replica count for agents  [[GH-290](https://github.com/hashicorp/terraform-cloud-operator/pull/290)]
+* `AgentPool`: Default agent pods to have a `terminationGracePeriod` of 15 minutes. [[GH-290](https://github.com/hashicorp/terraform-cloud-operator/pull/290)]
+
+DOCS:
+
+* Update FAQ. [[GH-271](https://github.com/hashicorp/terraform-cloud-operator/pull/271)]
+
+DEPENDENCIES:
+
+* Bump `sigs.k8s.io/controller-runtime` from 0.15.1 to 0.15.3. [[GH-258](https://github.com/hashicorp/terraform-cloud-operator/pull/258)] [[GH-294](https://github.com/hashicorp/terraform-cloud-operator/pull/294)]
+* Bump `github.com/hashicorp/go-slug` from 0.12.1 to 0.12.2. [[GH-261](https://github.com/hashicorp/terraform-cloud-operator/pull/261)]
+* Bump `k8s.io/api` from 0.27.5 to 0.27.7. [[GH-264](https://github.com/hashicorp/terraform-cloud-operator/pull/264)] [[GH-292](https://github.com/hashicorp/terraform-cloud-operator/pull/292)]
+* Bump `k8s.io/apimachinery` from 0.27.5 to 0.27.7. [[GH-264](https://github.com/hashicorp/terraform-cloud-operator/pull/264)] [[GH-292](https://github.com/hashicorp/terraform-cloud-operator/pull/292)]
+* Bump `k8s.io/client-go` from 0.27.5 to 0.27.7. [[GH-264](https://github.com/hashicorp/terraform-cloud-operator/pull/264)] [[GH-292](https://github.com/hashicorp/terraform-cloud-operator/pull/292)]
+* Bump `kube-rbac-proxy` image from `0.14.2` to `0.14.4`. [[GH-271](https://github.com/hashicorp/terraform-cloud-operator/pull/271)] [[GH-281](https://github.com/hashicorp/terraform-cloud-operator/pull/281)]
+* Bump `golang.org/x/net` from 0.14.0 to 0.17.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]
+* Bump `golang.org/x/sys` from 0.11.0 to 0.13.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]
+* Bump `golang.org/x/term` from 0.11.0 to 0.13.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]
+* Bump `golang.org/x/text` from 0.12.0 to 0.13.0. [[GH-272](https://github.com/hashicorp/terraform-cloud-operator/pull/272)]
+* Bump `github.com/hashicorp/go-tfe` from 1.32.1 to 1.35.0. [[GH-273](https://github.com/hashicorp/terraform-cloud-operator/pull/273)]
+* Bump `github.com/onsi/gomega` from 1.28.1 to 1.29.0. [[GH-291](https://github.com/hashicorp/terraform-cloud-operator/pull/291)]
+* Bump `github.com/go-logr/logr` from 1.2.4 to 1.3.0. [[GH-293](https://github.com/hashicorp/terraform-cloud-operator/pull/293)]
+
+## Community Contributors :raised_hands:
+- @kieranbrown made their contribution in https://github.com/hashicorp/terraform-cloud-operator/pull/259
+- @KamalAman for constantly providing us with a valuable feedback :rocket:
+
+## 2.0.0-beta8 (August 29, 2023)
+
+BUG FIXES:
+
+* `AgentPool`: fix an issue when `plan_queued` and `apply_queued` statuses do not trigger agent scaling. [[GH-215](https://github.com/hashicorp/terraform-cloud-operator/pull/215)]
+* `Helm Chart`: fix an issue with the Deployment template in the Helm chart where `name` in path `spec.template.spec.containers[0]` was duplicated. [[GH-216](https://github.com/hashicorp/terraform-cloud-operator/pull/216)]
+* `Workspace`: fix an issue when the Operator panics when `spec.executionMode` is configured as `agent` but `spec.agentPool` is not set which is mandatory in this case. [[GH-242](https://github.com/hashicorp/terraform-cloud-operator/pull/242)]
+* `Workspace`: fix an issue when a new Workspace is successfully created, but its `status.WorkspaceID` status fails to update with a new Workspace ID due to an error during subsequent reconciliation. Consequently, the Workspace controller continuously encounters failures while attempting to reconcile the newly created Workspace. [[GH-234](https://github.com/hashicorp/terraform-cloud-operator/pull/234)]
+
+ENHANCEMENT:
+
+* `Operator`: Add the ability to skip TLS certificate validation for communication between the Operator and the TFC/E endpoint. A new environment variable `TFC_TLS_SKIP_VERIFY` should be set to `true` to skip the validation. Default: `false`. [[GH-222](https://github.com/hashicorp/terraform-cloud-operator/pull/222)]
+* `Helm Chart`: Add a new parameter `operator.skipTLSVerify` to configure the ability to skip TLS certificate validation for communication between the Operator and the TFC/E endpoint. Default: `false`. [[GH-222](https://github.com/hashicorp/terraform-cloud-operator/pull/222)]
+* `Workspace`: Add `spec.Tags` validation to align with the TFC requirement. [[GH-234](https://github.com/hashicorp/terraform-cloud-operator/pull/234)]
+
+DEPENDENCIES:
+
+* Bump `github.com/hashicorp/go-tfe` from 1.29.0 to 1.32.1. [[GH-218](https://github.com/hashicorp/terraform-cloud-operator/pull/218)] [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)]
+* Bump `github.com/hashicorp/go-slug` from 0.11.1 to 0.12.1. [[GH-219](https://github.com/hashicorp/terraform-cloud-operator/pull/219)] [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)]
+* Bump `github.com/onsi/gomega` from 1.27.8 to 1.27.10. [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)]
+* Bump `go.uber.org/zap` from 1.24.0 to 1.25.0. [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)]
+* Bump `k8s.io/api` from 0.27.3 to 0.27.5. [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)] [[GH-252](https://github.com/hashicorp/terraform-cloud-operator/pull/252)]
+* Bump `k8s.io/apimachinery` from 0.27.3 to 0.27.5. [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)] [[GH-252](https://github.com/hashicorp/terraform-cloud-operator/pull/252)]
+* Bump `k8s.io/client-go` from 0.27.3 to 0.27.5. [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)] [[GH-252](https://github.com/hashicorp/terraform-cloud-operator/pull/252)]
+* Bump `sigs.k8s.io/controller-runtime` from 0.15.0 to 0.15.1. [[GH-247](https://github.com/hashicorp/terraform-cloud-operator/pull/247)]
+* Bump `kube-rbac-proxy` image from `0.13.1` to `0.14.2`. [[GH-251](https://github.com/hashicorp/terraform-cloud-operator/pull/251)]
+* Bump `github.com/onsi/ginkgo/v2` from 2.11.0 to 2.12.0. [[GH-254](https://github.com/hashicorp/terraform-cloud-operator/pull/254)]
+
+## 2.0.0-beta7 (July 07, 2023)
+
+NOTES:
+* `Helm Chart`: the Helm chart version is synced to the Terraform Cloud Operator version. [[GH-204](https://github.com/hashicorp/terraform-cloud-operator/pull/204)]
+
+BUG FIXES:
+
+* `Operator`: fix an issue when the operator couldn't be run on the `amd64` platform. [[GH-203](https://github.com/hashicorp/terraform-cloud-operator/pull/203)]
+
+ENHANCEMENT:
+* `Helm Chart`: `operator.image.tag` defaults to `.Chart.AppVersion`. [[GH-204](https://github.com/hashicorp/terraform-cloud-operator/pull/204)]
+* `Workspace`: add event filtering to reduce the number of unnecessary reconciliations. [[GH-194](https://github.com/hashicorp/terraform-cloud-operator/pull/194)]
+* `AgentPool`: add `autoscaling` field to allow configuration of a basic autoscaler for agent deployments based on pending runs. [[GH-198](https://github.com/hashicorp/terraform-cloud-operator/pull/198)]
+* `Workspace`: add Terraform version utilized in the Workspace to the status: `status.TerraformVersion`. [[GH-206](https://github.com/hashicorp/terraform-cloud-operator/pull/206)]
+
+DOCS:
+
+* Update FAQ. [[GH-206](https://github.com/hashicorp/terraform-cloud-operator/pull/206)]
+
+DEPENDENCIES:
+
+* Bump `k8s.io/api` from 0.27.2 to 0.27.3. [[GH-195](https://github.com/hashicorp/terraform-cloud-operator/pull/195)]
+* Bump `k8s.io/apimachinery` from 0.27.2 to 0.27.3. [[GH-195](https://github.com/hashicorp/terraform-cloud-operator/pull/195)]
+* Bump `k8s.io/client-go` from 0.27.2 to 0.27.3. [[GH-195](https://github.com/hashicorp/terraform-cloud-operator/pull/195)]
+* Bump `github.com/onsi/ginkgo/v2` from 2.9.5 to 2.11.0. [[GH-197](https://github.com/hashicorp/terraform-cloud-operator/pull/197)]
+* Bump `github.com/onsi/gomega` from 1.27.7 to 1.27.8. [[GH-197](https://github.com/hashicorp/terraform-cloud-operator/pull/197)]
+* Bump `github.com/hashicorp/go-tfe` from 1.23.0 to 1.29.0. [[GH-205](https://github.com/hashicorp/terraform-cloud-operator/pull/205)]
+
+## 2.0.0-beta6 (June 23, 2023)
+
+NOTES:
+* `Operator`: the Operator no longer includes the global option `--config`. [[GH-185](https://github.com/hashicorp/terraform-cloud-operator/pull/185)]
+* `Helm Chart`: the Helm chart no longer includes the ConfigMap `manager-config` as it has been removed. [[GH-185](https://github.com/hashicorp/terraform-cloud-operator/pull/185)]
+* `Helm Chart`: the Helm chart now allows configuration of custom CA bundles [[GH-173](https://github.com/hashicorp/terraform-cloud-operator/pull/173)]
+
+ENHANCEMENT:
+
+* `Module`: the Run now adopts the apply method of the Workspace in which it is executed. If the apply method is set to 'manual', the Run will remain on hold until it receives manual approval or rejection for the application or cancellation of the Run. [[GH-170](https://github.com/hashicorp/terraform-cloud-operator/pull/170)]
+* `Module`: add a new field `spec.name` that allows modifying the name of the module that is generated by the Operator. Default: `this`. [[GH-172](https://github.com/hashicorp/terraform-cloud-operator/pull/172)]
+* `Workspace`: mark fields `.status.ObservedGeneration`, `.status.UpdateAt`, and `.status.runStatus.configurationVersion` as optional. [[GH-186](https://github.com/hashicorp/terraform-cloud-operator/pull/186)]
+* `Workspace`: add an extra validation during the reconciliation to exit if the object contains the `v1` finalizer `finalizer.workspace.app.terraform.io`. [[GH-186](https://github.com/hashicorp/terraform-cloud-operator/pull/186)]
+
+DEPENDENCIES:
+
+* Bump `github.com/go-logr/zapr` from 1.2.3 to 1.2.4. [[GH-185](https://github.com/hashicorp/terraform-cloud-operator/pull/185)]
+* Bump `github.com/onsi/ginkgo/v2` from 2.9.4 to 2.9.5. [[GH-185](https://github.com/hashicorp/terraform-cloud-operator/pull/185)]
+* Bump `github.com/onsi/gomega` from 1.27.6 to 1.27.7. [[GH-185](https://github.com/hashicorp/terraform-cloud-operator/pull/185)]
+* Bump `k8s.io/api` from 0.26.3 to 0.27.2. [[GH-185](https://github.com/hashicorp/terraform-cloud-operator/pull/185)]
+* Bump `k8s.io/apimachinery` from 0.26.3 to 0.27.2. [[GH-185](https://github.com/hashicorp/terraform-cloud-operator/pull/185)]
+* Bump `k8s.io/client-go` from 0.26.3 to 0.27.2. [[GH-185](https://github.com/hashicorp/terraform-cloud-operator/pull/185)]
+* Bump `sigs.k8s.io/controller-runtime` from 0.14.6 to 0.15.0. [[GH-185](https://github.com/hashicorp/terraform-cloud-operator/pull/185)]
+
+## 2.0.0-beta5 (April 18, 2023)
+
+BUG FIXES:
+
+* RBAC fixes for agent deployment [[GH-135](https://github.com/hashicorp/terraform-cloud-operator/pull/135)], [[GH-143](https://github.com/hashicorp/terraform-cloud-operator/pull/134)]
+
+DEPENDENCIES:
+
+* Bump sigs.k8s.io/controller-runtime from 0.14.5 to 0.14.6 [[GH-132](https://github.com/hashicorp/terraform-cloud-operator/pull/132)]
+
+## 2.0.0-beta4 (March 28, 2023)
+
+ENHANCEMENT:
+
+* `AgentPool`: add custom resource `spec` validation. [[GH-79](https://github.com/hashicorp/terraform-cloud-operator/issues/79)]
+* `AgentPool`: add `agentDeployment` field to spec [[GH-96](https://github.com/hashicorp/terraform-cloud-operator/pull/96)]
+* `Module`: add custom resource `spec` validation. [[GH-79](https://github.com/hashicorp/terraform-cloud-operator/issues/79)]
+* `Workspace`: add custom resource `spec` validation. [[GH-79](https://github.com/hashicorp/terraform-cloud-operator/issues/79)]
+* `Workspace`: add `notifications` field to spec [[GH-107](https://github.com/hashicorp/terraform-cloud-operator/pull/107)]
+* `Workspace`: add `runTasks` field to spec [[GH-89](https://github.com/hashicorp/terraform-cloud-operator/pull/89)]
+
+BUG FIXES:
+
+* `Module`: fix an issue when custom resource fails if it refers to Workspace by ID. [[GH-77](https://github.com/hashicorp/terraform-cloud-operator/issues/77)]
+
+DEPENDENCIES:
+
+* Bump `github.com/onsi/ginkgo/v2` from 2.7.0 to 2.8.0. [[GH-73](https://github.com/hashicorp/terraform-cloud-operator/issues/73)]
+* Bump `sigs.k8s.io/controller-runtime` to 0.14.3. [[GH-78](https://github.com/hashicorp/terraform-cloud-operator/issues/78)]
+
+DOCS:
+
+* Update controllers documentation. [[GH-76](https://github.com/hashicorp/terraform-cloud-operator/issues/76)] [[GH-79](https://github.com/hashicorp/terraform-cloud-operator/issues/79)]
+* Update FAQ. [[GH-76](https://github.com/hashicorp/terraform-cloud-operator/issues/76)]
+* Update API Reference. [[GH-76](https://github.com/hashicorp/terraform-cloud-operator/issues/76)] [[GH-79](https://github.com/hashicorp/terraform-cloud-operator/issues/79)]
+* Add examples. [[GH-76](https://github.com/hashicorp/terraform-cloud-operator/issues/76)]
+
+## 2.0.0-beta3 (January 25, 2023)
+
+FEATURES:
+
+* `Operator`: add support for Terraform Enterprise endpoints via Helm chart variable `operator.tfeAddress`.
+
+BUG FIXES:
+
+* `AgentPool`: fix an issue when manually created agent tokens are not removed from Agent Pool during the reconciliation.
+
+DOCS:
+
+* Update documentation.
+* Add FAQ.
+* Reorganize documentation structure.

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -1,0 +1,23 @@
+changesDir: .changes
+unreleasedDir: unreleased
+changelogPath: CHANGELOG.md
+versionExt: md
+versionFormat: '## {{.Version}} ({{.Time.Format "January 02, 2006"}})'
+kindFormat: '{{.Kind}}:'
+changeFormat: '* {{.Body}} [[GH-{{.Custom.PR}}](https://github.com/hashicorp/terraform-cloud-operator/pull/{{.Custom.PR}})]'
+custom:
+  - key: PR
+    label: PR Number
+    type: int
+    minInt: 1
+kinds:
+  - label: BREAKING CHANGES
+  - label: BUG FIXES
+  - label: DEPENDENCIES
+  - label: ENHANCEMENTS
+  - label: FEATURES
+  - label: NOTES
+newlines:
+  afterKind: 1
+  beforeKind: 1
+  endOfVersion: 2

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -3,6 +3,7 @@ unreleasedDir: unreleased
 changelogPath: CHANGELOG.md
 versionExt: md
 versionFormat: '## {{.Version}} ({{.Time.Format "January 02, 2006"}})'
+fragmentFileFormat: '{{.Kind}}-{{.Custom.PR}}-{{.Time.Format "20060102-150405"}}'
 kindFormat: '{{.Kind}}:'
 changeFormat: '* {{.Body}} [[GH-{{.Custom.PR}}](https://github.com/hashicorp/terraform-cloud-operator/pull/{{.Custom.PR}})]'
 custom:
@@ -12,11 +13,17 @@ custom:
     minInt: 1
 kinds:
   - label: BREAKING CHANGES
+    auto: minor
   - label: BUG FIXES
+    auto: patch
   - label: DEPENDENCIES
+    auto: minor
   - label: ENHANCEMENTS
+    auto: minor
   - label: FEATURES
+    auto: minor
   - label: NOTES
+    auto: minor
 newlines:
   afterKind: 1
   beforeKind: 1

--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -9,5 +9,8 @@ project {
     # Some files were scaffolded during the first run of the operator-sdk CLI tool and never changed
     # The dev team is not working with these files they all serve a supporting role
     "config/**",
+    # Changie is a tool to manage changelog entries
+    ".changes/unreleased/*.yaml",
+    ".changie.yaml",
   ]
 }

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,27 +11,19 @@ Thank you!
 --->
 
 ### Description
+
 <!---
 Please describe your changes in detail.
 --->
 
 ### Usage Example
+
 <!---
 Please provide a usage example if you have implemented a new feature.
 --->
 
-### Release Note
-Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):
-<!--
-Please write a release note message.
-If the change is not user-facing, leave "NONE" in the release-note block below.
--->
-
-```release-note
-NONE
-```
-
 ### References
+
 <!---
 Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
 For example:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,6 +172,20 @@ There are two main pieces of the Operator `API` and `Controller`. Depending on w
 
     Every test should be executable through a make target, and the target should have a prefix of "test-".
 
+### Write a changelog
+
+We use the [Changie](https://changie.dev/) automation tool for changelog management.
+
+To add a new entry to the `CHANGELOG` install Changie using the following [instructions](https://changie.dev/guide/installation/) and run the following command:
+
+```console
+$ changie new
+```
+
+Follow the interactive menu steps to generate a new changelog entry in a `*.yaml` file that will appear in the `.changes/unreleased` folder. In the case of multiple changes, run the above command as many times as necessary.
+
+Ensure that the generated files are pushed to the repository along with any code changes.
+
 ## Submitting Changes
 
 ### Creating a Pull Request
@@ -181,8 +195,6 @@ We're excited that you're ready to contribute to the Operator by creating a pull
 1. **Description**: write a detailed description of your changes. Keep in mind, that it should be clear why you make this change, what you have changed, and how this will affect the Operator users. If you are working on a fix for an existing issue, you can provide less details about it.
 
 1. **Usage Example**: if your change is API-related, make sure you have provided **Before** and **After** usage examples.
-
-1. **Release Note**: write down a change log within the PR and update the [CHANGELOG.MD](./CHANGELOG.md) file respectively.
 
 1. **References**: if you fix an existing issue, please provide a reference to it by using a relevant [GitHub keyword](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue).
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,20 +8,47 @@ The Semantic Versioning agreement is being followed by this project. Further det
 
 To create a new release, adhere to the following steps:
 
-- Decide on the version number that you intend to release. Throughout the following steps, it will be denoted as `<SEMVER>`.
+- Switch to the `main` branch and fetch the latest changes.
+
+  ```console
+  $ git switch main
+  $ git pull
+  ```
+
+- Generate the version number that will be released. Throughout the following steps, it will be denoted as `<SEMVER>`.
+
+  ```console
+  $ export TFC_OPERATOR_RELEASE_VERSION=`changie next auto`
+  ```
 
 - Create a new branch from the `main`. The branch name is required to adhere to the following template: `release/v<SEMVER>`.
 
-- Modify the `version/VERSION` file to reflect the version number that you plan to release. The version number in this file must correspond with the `<SEMVER>` of the release branch name.
+  ```console
+  $ git checkout -b release/v$TFC_OPERATOR_RELEASE_VERSION
+  ```
 
-- Revise the [`CHANGELOG`](./CHANGELOG.md) file by renaming the unreleased version section to the version number of the release if necessary(for example, it might be `X.Y.Z`) or creating it if it doesn't already exist. The version number in this file must correspond with the `<SEMVER>` of the release branch name. Substitute `UNRELEASED` in the breast adjacent to the release version with the planned release date expressed as `Month DD, YYYY` format. Alternatively, execute the script [release-date.sh](./scripts/release-date.sh) to modify the [`CHANGELOG`](./CHANGELOG.md) file by substituting `UNRELEASED` with the current date.
+- Modify the `version/VERSION` file to reflect the version number that you plan to release.
 
-- Execute script [update-helm-chart.sh](./scripts/update-helm-chart.sh) to update the [`Chart.yaml`](./charts/terraform-cloud-operator/Chart.yaml) file to match the desired release number:
+  ```console
+  $ echo $TFC_OPERATOR_RELEASE_VERSION > version/VERSION
+  ```
 
-  - The values of `version` and `appVersion` will be updated based on the value set in the environment variable `VERSION`, or if it is not set, it will be derived from the file `version/VERSION`.
+- Update the [`CHANGELOG`](./CHANGELOG.md) file with the change that were made since the last release.
 
-- Create a pull request against the `main` branch and follow the regular code review and merge procedures.
+  ```console
+  $ changie batch auto
+  $ changie marge
+  ```
 
-- After merging the release branch into the `main` branch, a git tag should have been automatically created for the new release version number. The version number in the tag must correspond with the `<SEMVER>` of the merged release branch name. Confirm this succeeded by viewing the repository [tags](https://github.com/hashicorp/terraform-cloud-operator/tags).
+- Execute the script [update-helm-chart.sh](./scripts/update-helm-chart.sh) to update the [`Chart.yaml`](./charts/terraform-cloud-operator/Chart.yaml) file and match the desired release number. _The values of `version` and `appVersion` will be updated accordingly to the <SEMVER> value._
+
+
+  ```console
+  $ scripts/update-helm-chart.sh
+  ```
+
+- Create a pull request against the `main` branch and follow the standard code review and merge procedures.
+
+- After merging the release branch into the `main` branch, a git tag should have been automatically created for the new release version number. The version number in the tag must correspond with the `<SEMVER>` of the merged release branch name. Confirm this success by viewing the repository [tags](https://github.com/hashicorp/terraform-cloud-operator/tags).
 
 - Follow the [CRT Usage](https://hashicorp.atlassian.net/wiki/spaces/RELENG/pages/2309390389/Part+3+CRT+Usage) guide to promote the release to the staging and production states.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,7 +37,7 @@ To create a new release, adhere to the following steps:
 
   ```console
   $ changie batch auto
-  $ changie marge
+  $ changie merge
   ```
 
 - Execute the script [update-helm-chart.sh](./scripts/update-helm-chart.sh) to update the [`Chart.yaml`](./charts/terraform-cloud-operator/Chart.yaml) file and match the desired release number. _The values of `version` and `appVersion` will be updated accordingly to the <SEMVER> value._

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,6 +47,13 @@ To create a new release, adhere to the following steps:
   $ scripts/update-helm-chart.sh
   ```
 
+- Commit and push all changes that were made.
+
+  ```console
+  $ git add -A
+  $ git push
+  ```
+
 - Create a pull request against the `main` branch and follow the standard code review and merge procedures.
 
 - After merging the release branch into the `main` branch, a git tag should have been automatically created for the new release version number. The version number in the tag must correspond with the `<SEMVER>` of the merged release branch name. Confirm this success by viewing the repository [tags](https://github.com/hashicorp/terraform-cloud-operator/tags).

--- a/scripts/release-date.sh
+++ b/scripts/release-date.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# Copyright (c) HashiCorp, Inc.
-# SPDX-License-Identifier: MPL-2.0
-
-CHANGELOG_FILE="CHANGELOG.md"
-RELEASE_DATE=`date "+%B %d, %Y"`
-
-sed -i "" "s/UNRELEASED/$RELEASE_DATE/" $CHANGELOG_FILE

--- a/scripts/update-helm-chart.sh
+++ b/scripts/update-helm-chart.sh
@@ -13,7 +13,7 @@ function update_chart_file {
   C_VERSION=`yq '.appVersion' $CHART_DIR/$CHART_FILE`
   C_CHART_VERSION=`yq '.version' $CHART_DIR/$CHART_FILE`
 
-  if [[ $C_VERSION == $VERSION && $C_CHART_VERSION == $VERSION ]]; then
+  if [[ $C_VERSION == $TFC_OPERATOR_RELEASE_VERSION && $C_CHART_VERSION == $TFC_OPERATOR_RELEASE_VERSION ]]; then
     echo "No changes in the $CHART_FILE file."
     return 0
   fi
@@ -27,19 +27,19 @@ function update_chart_file {
 
 function main {
   if [[ -z "${VERSION}" ]]; then
-    echo "The environment variable VERSION is not set. Read value from ${VERSION_FILE}."
-    export VERSION=`cat $VERSION_FILE`
+    echo "The environment variable TFC_OPERATOR_RELEASE_VERSION is not set."
+    exit 1
   fi
 
   GIT_BRANCH=`git rev-parse --abbrev-ref HEAD | sed -e 's/^release\/v//'`
 
-  if [[ "$VERSION" != "$GIT_BRANCH" ]]; then
-    echo "The version in the git branch name '${GIT_BRANCH}' does not match with the release version '${VERSION}'."
+  if [[ "$TFC_OPERATOR_RELEASE_VERSION" != "$GIT_BRANCH" ]]; then
+    echo "The version in the git branch name '${GIT_BRANCH}' does not match with the release version '${TFC_OPERATOR_RELEASE_VERSION}'."
     echo "Exiting!"
     exit 1
   fi
 
-  echo "Version: ${VERSION}"
+  echo "Version: ${TFC_OPERATOR_RELEASE_VERSION}"
 
   update_chart_file
 }


### PR DESCRIPTION
### Description

Migrate changelog management to [Changie](https://changie.dev/).

_With this change, the release process can be further automated within a separate PR._

### Usage Example

N/A.

### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
NONE.
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
