### PR TITLE
🛠️ Add `helm-docs` tool to generate Helm chart README file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,10 @@ help: ## Display this help.
 docs: crd-ref-docs ## Generate API reference documentation.
 	$(CRD_REF_DOCS) --renderer=markdown --source-path ./api/v1alpha2/ --config=./docs/config.yaml --output-path ./docs/api-reference.md
 
+.PHONY: helm-docs
+helm-docs: install-helm-docs ## Generate Helm chart documentation.
+	$(HELM_DOCS) --log-level=debug --chart-search-root=./charts/terraform-cloud-operator/
+
 ##@ Development
 
 .PHONY: manifests
@@ -180,12 +184,14 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
+HELM_DOCS ?= $(LOCALBIN)/helm-docs
 HASHICORP_COPYWRITE ?= $(LOCALBIN)/copywrite
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.0.1
 CONTROLLER_TOOLS_VERSION ?= v0.11.3
 CRD_REF_DOCS_VERSION ?= v0.0.10
+HELM_DOCS_VERSION ?= v1.12.0
 HASHICORP_COPYWRITE_VERSION ?= 0.17.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
@@ -208,6 +214,11 @@ $(ENVTEST): $(LOCALBIN)
 crd-ref-docs: $(CRD_REF_DOCS) ## Download crd-ref-docs locally if necessary.
 $(CRD_REF_DOCS): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VERSION)
+
+.PHONY: install-helm-docs
+install-helm-docs: $(HELM_DOCS) ## Download helm-docs locally if necessary.
+$(HELM_DOCS): $(LOCALBIN)
+	GOBIN=$(LOCALBIN) go install github.com/norwoodj/helm-docs/cmd/helm-docs@$(HELM_DOCS_VERSION)
 
 .PHONY: install-copywrite
 install-copywrite: $(HASHICORP_COPYWRITE) ## Download HashiCorp copywrite locally if necessary.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -47,6 +47,8 @@ To create a new release, adhere to the following steps:
   $ scripts/update-helm-chart.sh
   ```
 
+- Run `make helm-docs` to update the Helm Chart [`README.md`](./charts/terraform-cloud-operator/README.md) file.
+
 - Commit and push all changes that were made.
 
   ```console

--- a/charts/terraform-cloud-operator/README.md
+++ b/charts/terraform-cloud-operator/README.md
@@ -135,4 +135,4 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | operator.syncPeriod | string | `"5m"` | The minimum frequency at which watched resources are reconciled. Format: `5s`, `1m`, etc. |
 | operator.tfeAddress | string | `""` | The API URL of a Terraform Enterprise instance. |
 | operator.watchedNamespaces | list | `[]` | List of namespaces the controllers should watch. |
-| replicaCount | int | `2` | Number of Terraform Cloud Operator replicas. |
+| replicaCount | int | `2` | The number of Terraform Cloud Operator replicas. |

--- a/charts/terraform-cloud-operator/README.md.gotmpl
+++ b/charts/terraform-cloud-operator/README.md.gotmpl
@@ -25,7 +25,7 @@ Use the option `--version VERSION` with `helm install` and `helm upgrade` comman
 
     ```console
     $ helm install demo hashicorp/terraform-cloud-operator \
-      --version 2.2.0 \
+      --version {{ template "chart.appVersion" . }} \
       --namespace tfc-operator-system \
       --create-namespace
     ```
@@ -36,7 +36,7 @@ Below are examples of the Operator installation/upgrade Helm chart with options.
 
 ```console
 $ helm install demo hashicorp/terraform-cloud-operator \
-  --version 2.2.0 \
+  --version {{ template "chart.appVersion" . }} \
   --namespace tfc-operator-system \
   --create-namespace \
   --set operator.syncPeriod=10m \
@@ -55,7 +55,7 @@ If targeting a Terraform Enterprise instance rather than Terraform Cloud, set th
 
 ```console
 $ helm install demo hashicorp/terraform-cloud-operator \
-  --version 2.2.0 \
+  --version {{ template "chart.appVersion" . }} \
   --set operator.tfeAddress="https://tfe-api.my-company.com"
 ```
 
@@ -67,7 +67,7 @@ For more information, please refer to the [FAQ](./../../docs/faq.md#general-ques
 
 ```console
 $ helm upgrade demo hashicorp/terraform-cloud-operator \
-  --version 2.2.0 \
+  --version {{ template "chart.appVersion" . }} \
   --namespace tfc-operator-system \
   --set operator.syncPeriod=5m \
   --set controllers.agentPool.workers=5 \
@@ -110,29 +110,4 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 
 # Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| controllers.agentPool.workers | int | `1` | The number of the Agent Pool controller workers. |
-| controllers.module.workers | int | `1` | The number of the Module controller workers. |
-| controllers.project.workers | int | `1` | The number of the Project controller workers. |
-| controllers.workspace.workers | int | `1` | The number of the Workspace controller workers. |
-| customCAcertificates | string | `""` | Custom Certificate Authority bundle to validate API TLS certificates. Expects a path to a CRT file containing concatenated certificates. |
-| kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
-| kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` | Image repository. |
-| kubeRbacProxy.image.tag | string | `"v0.15.0"` | Image tag. |
-| kubeRbacProxy.resources.limits.cpu | string | `"500m"` | Limits as a maximum amount of CPU to be used by a container. |
-| kubeRbacProxy.resources.limits.memory | string | `"128Mi"` | Limits as a maximum amount of memory to be used by a container. |
-| kubeRbacProxy.resources.requests.cpu | string | `"50m"` | Guaranteed minimum amount of CPU to be used by a container. |
-| kubeRbacProxy.resources.requests.memory | string | `"64Mi"` | Guaranteed minimum amount of memory to be used by a container. |
-| operator.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
-| operator.image.repository | string | `"hashicorp/terraform-cloud-operator"` | Image repository. |
-| operator.image.tag | string | `""` | Image tag. Defaults to `.Chart.AppVersion`. |
-| operator.resources.limits.cpu | string | `"500m"` | Limits as a maximum amount of CPU to be used by a container. |
-| operator.resources.limits.memory | string | `"128Mi"` | Limits as a maximum amount of memory to be used by a container. |
-| operator.resources.requests.cpu | string | `"50m"` | Guaranteed minimum amount of CPU to be used by a container. |
-| operator.resources.requests.memory | string | `"64Mi"` | Guaranteed minimum amount of memory to be used by a container. |
-| operator.skipTLSVerify | bool | `false` | Whether or not to ignore TLS certification warnings. |
-| operator.syncPeriod | string | `"5m"` | The minimum frequency at which watched resources are reconciled. Format: `5s`, `1m`, etc. |
-| operator.tfeAddress | string | `""` | The API URL of a Terraform Enterprise instance. |
-| operator.watchedNamespaces | list | `[]` | List of namespaces the controllers should watch. |
-| replicaCount | int | `2` | Number of Terraform Cloud Operator replicas. |
+{{ template "chart.valuesTable" . }}

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -1,65 +1,77 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MPL-2.0
 
+# -- The number of Terraform Cloud Operator replicas.
 replicaCount: 2
 
+# Operator-global options.
 operator:
   image:
+    # -- Image repository.
     repository: hashicorp/terraform-cloud-operator
+    # -- Image pull policy.
     pullPolicy: IfNotPresent
-    # 'tag' defaults to '.Chart.AppVersion'.
+    # -- Image tag. Defaults to `.Chart.AppVersion`.
     tag: ""
   resources:
     limits:
+      # -- Limits as a maximum amount of CPU to be used by a container.
       cpu: 500m
+      # -- Limits as a maximum amount of memory to be used by a container.
       memory: 128Mi
     requests:
+      # -- Guaranteed minimum amount of CPU to be used by a container.
       cpu: 50m
+      # -- Guaranteed minimum amount of memory to be used by a container.
       memory: 64Mi
 
-  # Operator-global options.
-  # The minimum frequency at which watched resources are reconciled.
-  # Format: 5s, 1m, etc.
+  # -- The minimum frequency at which watched resources are reconciled. Format: `5s`, `1m`, etc.
   syncPeriod: 5m
 
-  # List of namespaces the controllers should watch.
+  # -- List of namespaces the controllers should watch.
   watchedNamespaces: []
 
-  # The API URL of a TFE instance.
+  # -- The API URL of a Terraform Enterprise instance.
   tfeAddress: ""
 
-  # Whether or not to ignore TLS certification warnings.
+  # -- Whether or not to ignore TLS certification warnings.
   skipTLSVerify: false
 
 kubeRbacProxy:
   image:
+    # -- Image repository.
     repository: quay.io/brancz/kube-rbac-proxy
+    # -- Image pull policy.
     pullPolicy: IfNotPresent
+    # -- Image tag.
     tag: v0.15.0
 
   resources:
     limits:
+      # -- Limits as a maximum amount of CPU to be used by a container.
       cpu: 500m
+      # -- Limits as a maximum amount of memory to be used by a container.
       memory: 128Mi
     requests:
+      # -- Guaranteed minimum amount of CPU to be used by a container.
       cpu: 50m
+      # -- Guaranteed minimum amount of memory to be used by a container.
       memory: 64Mi
 
 # Controllers-specific options.
 controllers:
   agentPool:
-    # The number of the AgentPool controller workers.
+    # --  The number of the Agent Pool controller workers.
     workers: 1
   module:
-    # The number of the Module controller workers.
+    # -- The number of the Module controller workers.
     workers: 1
   project:
-    # The number of the Project controller workers.
+    # -- The number of the Project controller workers.
     workers: 1
   workspace:
-    # The number of the Workspace controller workers.
+    # -- The number of the Workspace controller workers.
     workers: 1
 
-# Custom Certificate Authority bundle to validate API TLS certificates.
-# Expects a path to a CRT file containing concatenated certificates.
+# -- Custom Certificate Authority bundle to validate API TLS certificates. Expects a path to a CRT file containing concatenated certificates.
 customCAcertificates: ""


### PR DESCRIPTION
### Description

This PR adds the ability to generate Helm chart README file by [helm-docs](https://github.com/norwoodj/helm-docs).

### Usage Example

```console
$ make helm-docs

~/bin/helm-docs --log-level=debug --chart-search-root=./charts/terraform-cloud-operator/
DEBU[2024-02-06T14:25:56+01:00] No ignore file found at ~/terraform-cloud-operator/.helmdocsignore, using empty ignore rules
INFO[2024-02-06T14:25:56+01:00] Found Chart directories [.]
DEBU[2024-02-06T14:25:56+01:00] Rendering from optional template files [README.md.gotmpl]
DEBU[2024-02-06T14:25:56+01:00] Rendering from optional template files [README.md.gotmpl]
INFO[2024-02-06T14:25:56+01:00] Generating README Documentation for chart charts/terraform-cloud-operator
DEBU[2024-02-06T14:25:56+01:00] Using template files [README.md.gotmpl] for chart charts/terraform-cloud-operator
```
### Release Note

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-cloud-operator/blob/main/CHANGELOG.md):

```release-note
NONE
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
