### PR TITLE
🚀 Add VCS Speculative Plan option

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-342-20240215-111818.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-342-20240215-111818.yaml
@@ -1,6 +1,6 @@
 kind: ENHANCEMENTS
 body: '`Workspace`: Add the ability to configure automatic speculative plan on pull
-  requests when using Version Control via a new optional field `spec.versionControl.speculativePlan`.
+  requests when using Version Control via a new optional field `spec.versionControl.speculativePlans`.
   Default to `true`.'
 time: 2024-02-15T11:18:18.677792+01:00
 custom:

--- a/.changes/unreleased/ENHANCEMENTS-342-20240215-111818.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-342-20240215-111818.yaml
@@ -1,0 +1,7 @@
+kind: ENHANCEMENTS
+body: '`Workspace`: Add the ability to configure automatic speculative plan on pull
+  requests when using Version Control via a new optional field `spec.versionControl.speculativePlan`.
+  Default to `true`.'
+time: 2024-02-15T11:18:18.677792+01:00
+custom:
+  PR: "342"

--- a/.changes/unreleased/NOTES-342-20240215-113038.yaml
+++ b/.changes/unreleased/NOTES-342-20240215-113038.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: The `Workspace` CRD has been changed. Please follow the Helm chart instructions
+  on how to upgrade it.
+time: 2024-02-15T11:30:38.232393+01:00
+custom:
+  PR: "342"

--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -292,6 +292,14 @@ type VersionControl struct {
 	//+kubebuilder:validation:MinLength:=1
 	//+optional
 	Branch string `json:"branch,omitempty"`
+	// Whether this workspace allows automatic speculative plans on PR.
+	// Default: `true`.
+	// More information:
+	//   - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans
+	//
+	//+kubebuilder:default=true
+	//+optional
+	SpeculativePlan bool `json:"speculativePlan"`
 }
 
 // SSH key used to clone Terraform modules.

--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -295,6 +295,7 @@ type VersionControl struct {
 	// Whether this workspace allows automatic speculative plans on PR.
 	// Default: `true`.
 	// More information:
+	//   - https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests
 	//   - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans
 	//
 	//+kubebuilder:default=true

--- a/api/v1alpha2/workspace_types.go
+++ b/api/v1alpha2/workspace_types.go
@@ -300,7 +300,7 @@ type VersionControl struct {
 	//
 	//+kubebuilder:default=true
 	//+optional
-	SpeculativePlan bool `json:"speculativePlan"`
+	SpeculativePlans bool `json:"speculativePlans"`
 }
 
 // SSH key used to clone Terraform modules.

--- a/charts/terraform-cloud-operator/README.md
+++ b/charts/terraform-cloud-operator/README.md
@@ -84,6 +84,14 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 
 #### Upgrade recommendations
 
+  - `2.2.0` to `2.3.0`
+
+    - The `Workspace` CRD has been changed:
+
+      ```console
+      $ kubectl replace -f https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/v2.3.0/charts/terraform-cloud-operator/crds/app.terraform.io_workspaces.yaml
+      ```
+
   - `2.1.0` to `2.2.0`
 
     - A new controller `Project` has been added:

--- a/charts/terraform-cloud-operator/README.md.gotmpl
+++ b/charts/terraform-cloud-operator/README.md.gotmpl
@@ -84,6 +84,14 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 
 #### Upgrade recommendations
 
+  - `2.2.0` to `2.3.0`
+
+    - The `Workspace` CRD has been changed:
+
+      ```console
+      $ kubectl replace -f https://raw.githubusercontent.com/hashicorp/terraform-cloud-operator/v2.3.0/charts/terraform-cloud-operator/crds/app.terraform.io_workspaces.yaml
+      ```
+
   - `2.1.0` to `2.2.0`
 
     - A new controller `Project` has been added:

--- a/charts/terraform-cloud-operator/crds/app.terraform.io_workspaces.yaml
+++ b/charts/terraform-cloud-operator/crds/app.terraform.io_workspaces.yaml
@@ -603,7 +603,7 @@ spec:
                       refer to the organization and repository in your VCS provider.
                     minLength: 1
                     type: string
-                  speculativePlan:
+                  speculativePlans:
                     default: true
                     description: 'Whether this workspace allows automatic speculative
                       plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests

--- a/charts/terraform-cloud-operator/crds/app.terraform.io_workspaces.yaml
+++ b/charts/terraform-cloud-operator/crds/app.terraform.io_workspaces.yaml
@@ -603,6 +603,11 @@ spec:
                       refer to the organization and repository in your VCS provider.
                     minLength: 1
                     type: string
+                  speculativePlan:
+                    default: true
+                    description: 'Whether this workspace allows automatic speculative
+                      plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans'
+                    type: boolean
                 type: object
               workingDirectory:
                 description: 'The directory where Terraform will execute, specified

--- a/charts/terraform-cloud-operator/crds/app.terraform.io_workspaces.yaml
+++ b/charts/terraform-cloud-operator/crds/app.terraform.io_workspaces.yaml
@@ -606,7 +606,8 @@ spec:
                   speculativePlan:
                     default: true
                     description: 'Whether this workspace allows automatic speculative
-                      plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans'
+                      plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests
+                      - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans'
                     type: boolean
                 type: object
               workingDirectory:

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -600,6 +600,11 @@ spec:
                       refer to the organization and repository in your VCS provider.
                     minLength: 1
                     type: string
+                  speculativePlan:
+                    default: true
+                    description: 'Whether this workspace allows automatic speculative
+                      plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans'
+                    type: boolean
                 type: object
               workingDirectory:
                 description: 'The directory where Terraform will execute, specified

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -603,7 +603,8 @@ spec:
                   speculativePlan:
                     default: true
                     description: 'Whether this workspace allows automatic speculative
-                      plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans'
+                      plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests
+                      - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans'
                     type: boolean
                 type: object
               workingDirectory:

--- a/config/crd/bases/app.terraform.io_workspaces.yaml
+++ b/config/crd/bases/app.terraform.io_workspaces.yaml
@@ -600,7 +600,7 @@ spec:
                       refer to the organization and repository in your VCS provider.
                     minLength: 1
                     type: string
-                  speculativePlan:
+                  speculativePlans:
                     default: true
                     description: 'Whether this workspace allows automatic speculative
                       plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -266,13 +266,13 @@ func (r *WorkspaceReconciler) updateStatus(ctx context.Context, w *workspaceInst
 func (r *WorkspaceReconciler) createWorkspace(ctx context.Context, w *workspaceInstance) (*tfc.Workspace, error) {
 	spec := w.instance.Spec
 	options := tfc.WorkspaceCreateOptions{
-		Name:             tfc.String(spec.Name),
-		AllowDestroyPlan: tfc.Bool(spec.AllowDestroyPlan),
-		AutoApply:        tfc.Bool(applyMethodToBool(spec.ApplyMethod)),
-		Description:      tfc.String(spec.Description),
-		ExecutionMode:    tfc.String(spec.ExecutionMode),
-		TerraformVersion: tfc.String(spec.TerraformVersion),
-		WorkingDirectory: tfc.String(spec.WorkingDirectory),
+		Name:               tfc.String(spec.Name),
+		AllowDestroyPlan:   tfc.Bool(spec.AllowDestroyPlan),
+		AutoApply:          tfc.Bool(applyMethodToBool(spec.ApplyMethod)),
+		Description:        tfc.String(spec.Description),
+		ExecutionMode:      tfc.String(spec.ExecutionMode),
+		TerraformVersion:   tfc.String(spec.TerraformVersion),
+		WorkingDirectory:   tfc.String(spec.WorkingDirectory),
 	}
 
 	if spec.ExecutionMode == "agent" {
@@ -293,6 +293,7 @@ func (r *WorkspaceReconciler) createWorkspace(ctx context.Context, w *workspaceI
 			Branch:       tfc.String(spec.VersionControl.Branch),
 		}
 		options.FileTriggersEnabled = tfc.Bool(false)
+		options.SpeculativeEnabled = tfc.Bool(spec.VersionControl.SpeculativePlan)
 	}
 
 	if spec.RemoteStateSharing != nil {
@@ -401,6 +402,10 @@ func (r *WorkspaceReconciler) updateWorkspace(ctx context.Context, w *workspaceI
 			Branch:       tfc.String(spec.VersionControl.Branch),
 		}
 		updateOptions.FileTriggersEnabled = tfc.Bool(false)
+
+		if workspace.SpeculativeEnabled != spec.VersionControl.SpeculativePlan {
+			updateOptions.SpeculativeEnabled = tfc.Bool(spec.VersionControl.SpeculativePlan)
+		}
 	}
 
 	if spec.Project != nil {

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -293,7 +293,7 @@ func (r *WorkspaceReconciler) createWorkspace(ctx context.Context, w *workspaceI
 			Branch:       tfc.String(spec.VersionControl.Branch),
 		}
 		options.FileTriggersEnabled = tfc.Bool(false)
-		options.SpeculativeEnabled = tfc.Bool(spec.VersionControl.SpeculativePlan)
+		options.SpeculativeEnabled = tfc.Bool(spec.VersionControl.SpeculativePlans)
 	}
 
 	if spec.RemoteStateSharing != nil {
@@ -403,8 +403,8 @@ func (r *WorkspaceReconciler) updateWorkspace(ctx context.Context, w *workspaceI
 		}
 		updateOptions.FileTriggersEnabled = tfc.Bool(false)
 
-		if workspace.SpeculativeEnabled != spec.VersionControl.SpeculativePlan {
-			updateOptions.SpeculativeEnabled = tfc.Bool(spec.VersionControl.SpeculativePlan)
+		if workspace.SpeculativeEnabled != spec.VersionControl.SpeculativePlans {
+			updateOptions.SpeculativeEnabled = tfc.Bool(spec.VersionControl.SpeculativePlans)
 		}
 	}
 

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -266,13 +266,13 @@ func (r *WorkspaceReconciler) updateStatus(ctx context.Context, w *workspaceInst
 func (r *WorkspaceReconciler) createWorkspace(ctx context.Context, w *workspaceInstance) (*tfc.Workspace, error) {
 	spec := w.instance.Spec
 	options := tfc.WorkspaceCreateOptions{
-		Name:               tfc.String(spec.Name),
-		AllowDestroyPlan:   tfc.Bool(spec.AllowDestroyPlan),
-		AutoApply:          tfc.Bool(applyMethodToBool(spec.ApplyMethod)),
-		Description:        tfc.String(spec.Description),
-		ExecutionMode:      tfc.String(spec.ExecutionMode),
-		TerraformVersion:   tfc.String(spec.TerraformVersion),
-		WorkingDirectory:   tfc.String(spec.WorkingDirectory),
+		Name:             tfc.String(spec.Name),
+		AllowDestroyPlan: tfc.Bool(spec.AllowDestroyPlan),
+		AutoApply:        tfc.Bool(applyMethodToBool(spec.ApplyMethod)),
+		Description:      tfc.String(spec.Description),
+		ExecutionMode:    tfc.String(spec.ExecutionMode),
+		TerraformVersion: tfc.String(spec.TerraformVersion),
+		WorkingDirectory: tfc.String(spec.WorkingDirectory),
 	}
 
 	if spec.ExecutionMode == "agent" {

--- a/controllers/workspace_controller_vcs_test.go
+++ b/controllers/workspace_controller_vcs_test.go
@@ -69,10 +69,10 @@ var _ = Describe("Workspace controller", Ordered, func() {
 				},
 				Name: workspace,
 				VersionControl: &appv1alpha2.VersionControl{
-					OAuthTokenID:    oAuthTokenID,
-					Repository:      repository,
-					Branch:          "operator",
-					SpeculativePlan: true,
+					OAuthTokenID:     oAuthTokenID,
+					Repository:       repository,
+					Branch:           "operator",
+					SpeculativePlans: true,
 				},
 			},
 			Status: appv1alpha2.WorkspaceStatus{},
@@ -208,11 +208,11 @@ var _ = Describe("Workspace controller", Ordered, func() {
 				return ws.VCSRepo.OAuthTokenID == instanceCopy.Spec.VersionControl.OAuthTokenID &&
 					ws.VCSRepo.Identifier == instanceCopy.Spec.VersionControl.Repository &&
 					ws.VCSRepo.Branch == instanceCopy.Spec.VersionControl.Branch &&
-					ws.SpeculativeEnabled == instanceCopy.Spec.VersionControl.SpeculativePlan
+					ws.SpeculativeEnabled == instanceCopy.Spec.VersionControl.SpeculativePlans
 			}).Should(BeTrue())
 
 			// Update the Kubernetes workspace object fields
-			instance.Spec.VersionControl.SpeculativePlan = false
+			instance.Spec.VersionControl.SpeculativePlans = false
 			// Make a copy of the original instance to then compare Workspace against it
 			// It helps to make sure that the 'Spec' part is not mutated
 			instanceCopy = instance.DeepCopy()
@@ -230,7 +230,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 				return ws.VCSRepo.OAuthTokenID == instanceCopy.Spec.VersionControl.OAuthTokenID &&
 					ws.VCSRepo.Identifier == instanceCopy.Spec.VersionControl.Repository &&
 					ws.VCSRepo.Branch == instanceCopy.Spec.VersionControl.Branch &&
-					ws.SpeculativeEnabled == instanceCopy.Spec.VersionControl.SpeculativePlan
+					ws.SpeculativeEnabled == instanceCopy.Spec.VersionControl.SpeculativePlans
 			}).Should(BeTrue())
 		})
 	})

--- a/controllers/workspace_controller_vcs_test.go
+++ b/controllers/workspace_controller_vcs_test.go
@@ -69,9 +69,9 @@ var _ = Describe("Workspace controller", Ordered, func() {
 				},
 				Name: workspace,
 				VersionControl: &appv1alpha2.VersionControl{
-					OAuthTokenID: oAuthTokenID,
-					Repository:   repository,
-					Branch:       "operator",
+					OAuthTokenID:    oAuthTokenID,
+					Repository:      repository,
+					Branch:          "operator",
 					SpeculativePlan: true,
 				},
 			},
@@ -194,7 +194,7 @@ var _ = Describe("Workspace controller", Ordered, func() {
 			instanceCopy := instance.DeepCopy()
 
 			// Create a new Kubernetes workspace object and wait until the controller finishes the reconciliation
-			createWorkspace(instance, namespacedName)
+			createWorkspace(instance)
 
 			// Validate that all attributes are set correctly
 			Eventually(func() bool {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -578,7 +578,7 @@ _Appears in:_
 | `oAuthTokenID` _string_ | The VCS Connection (OAuth Connection + Token) to use. Must match pattern: `^ot-[a-zA-Z0-9]+$` |
 | `repository` _string_ | A reference to your VCS repository in the format `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization and repository in your VCS provider. |
 | `branch` _string_ | The repository branch that Run will execute from. This defaults to the repository's default branch (e.g. main). |
-| `speculativePlan` _boolean_ | Whether this workspace allows automatic speculative plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans |
+| `speculativePlans` _boolean_ | Whether this workspace allows automatic speculative plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans |
 
 
 #### Workspace

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -578,7 +578,7 @@ _Appears in:_
 | `oAuthTokenID` _string_ | The VCS Connection (OAuth Connection + Token) to use. Must match pattern: `^ot-[a-zA-Z0-9]+$` |
 | `repository` _string_ | A reference to your VCS repository in the format `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization and repository in your VCS provider. |
 | `branch` _string_ | The repository branch that Run will execute from. This defaults to the repository's default branch (e.g. main). |
-| `speculativePlan` _boolean_ | Whether this workspace allows automatic speculative plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans |
+| `speculativePlan` _boolean_ | Whether this workspace allows automatic speculative plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans |
 
 
 #### Workspace

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -578,6 +578,7 @@ _Appears in:_
 | `oAuthTokenID` _string_ | The VCS Connection (OAuth Connection + Token) to use. Must match pattern: `^ot-[a-zA-Z0-9]+$` |
 | `repository` _string_ | A reference to your VCS repository in the format `<organization>/<repository>` where `<organization>` and `<repository>` refer to the organization and repository in your VCS provider. |
 | `branch` _string_ | The repository branch that Run will execute from. This defaults to the repository's default branch (e.g. main). |
+| `speculativePlan` _boolean_ | Whether this workspace allows automatic speculative plans on PR. Default: `true`. More information: - https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans |
 
 
 #### Workspace


### PR DESCRIPTION
### Description

Add the ability to enable or disable automatic speculative plans on pull requests:

- https://developer.hashicorp.com/terraform/cloud-docs/run/ui#speculative-plans-on-pull-requests
- https://developer.hashicorp.com/terraform/cloud-docs/run/remote-operations#speculative-plans

Tests:

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8252317239
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8252319310

### Usage Example

```yaml
apiVersion: app.terraform.io/v1alpha2
kind: Workspace
metadata:
  name: this
spec:
  ...
  versionControl:
    oAuthTokenID: ot-this
    repository: this
    speculativePlans: false # THIS IS A NEW OPTION
```

### References

- Close: https://github.com/hashicorp/terraform-cloud-operator/issues/238

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
