### PR TITLE
🤖 Fix PR labeler GH action

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -12,8 +12,8 @@ dependencies:
 - 'go.sum'
 
 documentation:
-- '!CHANGELOG.md'
-- '*.md'
+- any: ['*.md']
+  all: ['!CHANGELOG.md']
 - 'charts/**/*.md'
 - 'docs/*.md'
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Label Pull Request
-      uses: actions/labeler@ba790c862c380240c6d5e7427be5ace9a05c754b # v4.0.3
+      uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
       with:
         configuration-path: .github/pr-labeler.yml
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Description

This PR fixes an issue when all changes get a `documentation` label and bumps `actions/labeler` from `4.0.3` to `4.3.0`.

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
