### PR TITLE
🛠️ Add new Run status methods: `RunCompleted` and `RunApplied`

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-351-20240229-092321.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-351-20240229-092321.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: '`Module`: The output will be synchronized when the run status is either `applied`
+  or `planned_and_finished`, whereas previously it was only `applied`.'
+time: 2024-02-29T09:23:21.918703+01:00
+custom:
+  PR: "351"

--- a/api/v1alpha2/helpers.go
+++ b/api/v1alpha2/helpers.go
@@ -1,0 +1,48 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package v1alpha2
+
+import (
+	tfc "github.com/hashicorp/go-tfe"
+)
+
+func (rs *RunStatus) RunCompleted() bool {
+	return runCompleted(rs.Status)
+}
+
+// runCompleted returns true if the run is completed
+func runCompleted(status string) bool {
+	// The following Run statuses indicate the completion
+	switch status {
+	case string(tfc.RunApplied):
+		return true
+	case string(tfc.RunPlannedAndFinished):
+		return true
+	case string(tfc.RunErrored):
+		return true
+	case string(tfc.RunCanceled):
+		return true
+	case string(tfc.RunDiscarded):
+		return true
+	}
+
+	return false
+}
+
+func (rs *RunStatus) RunApplied() bool {
+	return runCompleted(rs.Status)
+}
+
+// runApplied returns true if the run is applied
+func runApplied(status string) bool {
+	// The following Run statuses indicate the completion
+	switch status {
+	case string(tfc.RunApplied):
+		return true
+	case string(tfc.RunPlannedAndFinished):
+		return true
+	}
+
+	return false
+}

--- a/api/v1alpha2/helpers.go
+++ b/api/v1alpha2/helpers.go
@@ -31,7 +31,7 @@ func runCompleted(status string) bool {
 }
 
 func (rs *RunStatus) RunApplied() bool {
-	return runCompleted(rs.Status)
+	return runApplied(rs.Status)
 }
 
 // runApplied returns true if the run is applied

--- a/api/v1alpha2/helpers_test.go
+++ b/api/v1alpha2/helpers_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package v1alpha2
+
+import (
+	"testing"
+
+	tfc "github.com/hashicorp/go-tfe"
+)
+
+var runStatuses = map[tfc.RunStatus]struct{}{
+	tfc.RunApplied:                  {},
+	tfc.RunApplying:                 {},
+	tfc.RunApplyQueued:              {},
+	tfc.RunCanceled:                 {},
+	tfc.RunConfirmed:                {},
+	tfc.RunCostEstimated:            {},
+	tfc.RunCostEstimating:           {},
+	tfc.RunDiscarded:                {},
+	tfc.RunErrored:                  {},
+	tfc.RunFetching:                 {},
+	tfc.RunFetchingCompleted:        {},
+	tfc.RunPending:                  {},
+	tfc.RunPlanned:                  {},
+	tfc.RunPlannedAndFinished:       {},
+	tfc.RunPlannedAndSaved:          {},
+	tfc.RunPlanning:                 {},
+	tfc.RunPlanQueued:               {},
+	tfc.RunPolicyChecked:            {},
+	tfc.RunPolicyChecking:           {},
+	tfc.RunPolicyOverride:           {},
+	tfc.RunPolicySoftFailed:         {},
+	tfc.RunPostPlanAwaitingDecision: {},
+	tfc.RunPostPlanCompleted:        {},
+	tfc.RunPostPlanRunning:          {},
+	tfc.RunPreApplyRunning:          {},
+	tfc.RunPreApplyCompleted:        {},
+	tfc.RunPrePlanCompleted:         {},
+	tfc.RunPrePlanRunning:           {},
+	tfc.RunQueuing:                  {},
+	tfc.RunQueuingApply:             {},
+}
+
+func TestRunCompleted(t *testing.T) {
+	t.Parallel()
+
+	trueCases := map[tfc.RunStatus]struct{}{
+		tfc.RunApplied:            {},
+		tfc.RunCanceled:           {},
+		tfc.RunDiscarded:          {},
+		tfc.RunErrored:            {},
+		tfc.RunPlannedAndFinished: {},
+	}
+
+	for n := range runStatuses {
+		t.Run(string(n), func(t *testing.T) {
+			if runCompleted(string(n)) {
+				if _, ok := trueCases[n]; !ok {
+					t.Fatalf("Expected result to be false but got true for status %#v", n)
+				}
+			}
+		})
+	}
+}
+
+func TestRunApplied(t *testing.T) {
+	t.Parallel()
+
+	trueCases := map[tfc.RunStatus]struct{}{
+		tfc.RunApplied:            {},
+		tfc.RunPlannedAndFinished: {},
+	}
+
+	for n := range runStatuses {
+		t.Run(string(n), func(t *testing.T) {
+			if runApplied(string(n)) {
+				if _, ok := trueCases[n]; !ok {
+					t.Fatalf("Expected result to be false but got true for status %#v", n)
+				}
+			}
+		})
+	}
+}

--- a/controllers/module_controller_outputs.go
+++ b/controllers/module_controller_outputs.go
@@ -147,7 +147,7 @@ func needToUpdateOutput(instance *appv1alpha2.Module) bool {
 	if status.Output == nil {
 		return true
 	}
-	if status.Run.Status == string(tfc.RunApplied) && status.Run.ID != status.Output.RunID {
+	if status.Run.RunApplied() && status.Run.ID != status.Output.RunID {
 		return true
 	}
 


### PR DESCRIPTION
### Description

This PR brings two related changes:

- Makes the `Module` controller synchronize output when the run status is either `applied` or `planned_and_finished`, whereas previously it was only `applied`.
- Adds `RunCompleted` and `RunApplied` methods to the `RunStatus` structure.

#### Tests

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8093096531
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8093098023

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
