### PR TITLE
🛠️ Refactor outputs tests

### DIFF
--- a/controllers/workspace_controller_outputs_test.go
+++ b/controllers/workspace_controller_outputs_test.go
@@ -155,8 +155,8 @@ func createAndUploadConfigurationVersion(instance *appv1alpha2.Workspace, output
 		AutoQueueRuns: tfc.Bool(true),
 		Speculative:   tfc.Bool(false),
 	})
-	Expect(cv).ShouldNot(BeNil())
 	Expect(err).Should(Succeed())
+	Expect(cv).ShouldNot(BeNil())
 
 	Expect(tfClient.ConfigurationVersions.Upload(ctx, cv.UploadURL, td)).Should(Succeed())
 


### PR DESCRIPTION
### Description

This PR moves the create and upload the configuration version step to a separate function to reuse it further.

#### Tests

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8094177607
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8094178998

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
