### PR TITLE
🚀 Handle a case when Workspace does not have variables

### DIFF
--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -576,7 +576,7 @@ func (r *WorkspaceReconciler) reconcileWorkspace(ctx context.Context, w *workspa
 	r.Recorder.Eventf(&w.instance, corev1.EventTypeNormal, "ReconcileTags", "Successfully reconcilied tags in workspace ID %s", w.instance.Status.WorkspaceID)
 
 	// Reconcile Variables
-	err = r.reconcileVariables(ctx, w)
+	err = r.reconcileVariables(ctx, w, workspace)
 	if err != nil {
 		w.log.Error(err, "Reconcile Variables", "msg", fmt.Sprintf("failed to reconcile variables in workspace ID %s", w.instance.Status.WorkspaceID))
 		r.Recorder.Eventf(&w.instance, corev1.EventTypeWarning, "ReconcileVariables", "Failed to reconcile variables in workspace ID %s", w.instance.Status.WorkspaceID)

--- a/controllers/workspace_controller_variables.go
+++ b/controllers/workspace_controller_variables.go
@@ -111,10 +111,14 @@ func (r *WorkspaceReconciler) createWorkspaceVariables(ctx context.Context, w *w
 }
 
 // getWorkspaceVariables returns a list of all variables associated with the workspace.
-func (r *WorkspaceReconciler) getWorkspaceVariables(ctx context.Context, w *workspaceInstance) ([]*tfc.Variable, error) {
+func (r *WorkspaceReconciler) getWorkspaceVariables(ctx context.Context, w *workspaceInstance, workspace *tfc.Workspace) ([]*tfc.Variable, error) {
+	if workspace.Variables == nil {
+		return []*tfc.Variable{}, nil
+	}
+
 	v, err := w.tfClient.Client.Variables.List(ctx, w.instance.Status.WorkspaceID, &tfc.VariableListOptions{})
 	if err != nil {
-		return []*tfc.Variable{}, err
+		return nil, err
 	}
 	return v.Items, nil
 }
@@ -260,9 +264,15 @@ func getWorkspaceVariablesByCategory(workspaceVariables []*tfc.Variable, categor
 }
 
 func (r *WorkspaceReconciler) reconcileVariablesByCategory(ctx context.Context, w *workspaceInstance, variables []*tfc.Variable, category tfc.CategoryType) error {
-	workspaceID := w.instance.Status.WorkspaceID
 	instanceVariables := r.getVariablesByCategory(ctx, w, category)
 	workspaceVariables := getWorkspaceVariablesByCategory(variables, category)
+
+	if len(instanceVariables) == 0 && len(workspaceVariables) == 0 {
+		w.log.Info("Reconcile Variables", "msg", fmt.Sprintf("there are no %s variables both in spec and workspace", category))
+		return nil
+	}
+
+	workspaceID := w.instance.Status.WorkspaceID
 
 	daleteVariables := getVariablesToDelete(instanceVariables, workspaceVariables)
 	if len(daleteVariables) > 0 {
@@ -303,20 +313,20 @@ func (r *WorkspaceReconciler) reconcileVariablesByCategory(ctx context.Context, 
 	return nil
 }
 
-func (r *WorkspaceReconciler) reconcileVariables(ctx context.Context, w *workspaceInstance) error {
+func (r *WorkspaceReconciler) reconcileVariables(ctx context.Context, w *workspaceInstance, workspace *tfc.Workspace) error {
 	w.log.Info("Reconcile Variables", "msg", "new reconciliation event")
 
-	workspaceVariables, err := r.getWorkspaceVariables(ctx, w)
+	workspaceVariables, err := r.getWorkspaceVariables(ctx, w, workspace)
 	if err != nil {
 		return err
 	}
 
-	// Reconcilt Terraform Variables
+	// Reconcile Terraform Variables
 	if err = r.reconcileVariablesByCategory(ctx, w, workspaceVariables, tfc.CategoryTerraform); err != nil {
 		return err
 	}
 
-	// Reconcilt Environment Variables
+	// Reconcile Environment Variables
 	if err = r.reconcileVariablesByCategory(ctx, w, workspaceVariables, tfc.CategoryEnv); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

This PR adds coverage for an edge case when Workspace does not have variables. This allows making fewer API calls.

#### Tests

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8702099213
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8702100471

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
