### PR TITLE
🧹 Remove `getToken` methods

### DIFF
--- a/controllers/agentpool_controller.go
+++ b/controllers/agentpool_controller.go
@@ -117,24 +117,12 @@ func (r *AgentPoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *AgentPoolReconciler) getToken(ctx context.Context, instance *appv1alpha2.AgentPool) (string, error) {
-	secretName := instance.Spec.Token.SecretKeyRef.Name
-	secretKey := instance.Spec.Token.SecretKeyRef.Key
-
-	objectKey := types.NamespacedName{
-		Namespace: instance.Namespace,
-		Name:      secretName,
-	}
-	token, err := secretKeyRef(ctx, r.Client, objectKey, secretKey)
-	if err != nil {
-		return "", err
-	}
-
-	return token, nil
-}
-
 func (r *AgentPoolReconciler) getTerraformClient(ctx context.Context, ap *agentPoolInstance) error {
-	token, err := r.getToken(ctx, &ap.instance)
+	nn := types.NamespacedName{
+		Namespace: ap.instance.Namespace,
+		Name:      ap.instance.Spec.Token.SecretKeyRef.Name,
+	}
+	token, err := secretKeyRef(ctx, r.Client, nn, ap.instance.Spec.Token.SecretKeyRef.Key)
 	if err != nil {
 		return err
 	}

--- a/controllers/module_controller.go
+++ b/controllers/module_controller.go
@@ -184,24 +184,12 @@ func (r *ModuleReconciler) updateStatusDestroy(ctx context.Context, instance *ap
 	return r.Status().Update(ctx, instance)
 }
 
-func (r *ModuleReconciler) getToken(ctx context.Context, instance *appv1alpha2.Module) (string, error) {
-	secretName := instance.Spec.Token.SecretKeyRef.Name
-	secretKey := instance.Spec.Token.SecretKeyRef.Key
-
-	objectKey := types.NamespacedName{
-		Namespace: instance.Namespace,
-		Name:      secretName,
-	}
-	token, err := secretKeyRef(ctx, r.Client, objectKey, secretKey)
-	if err != nil {
-		return "", err
-	}
-
-	return token, nil
-}
-
 func (r *ModuleReconciler) getTerraformClient(ctx context.Context, m *moduleInstance) error {
-	token, err := r.getToken(ctx, &m.instance)
+	nn := types.NamespacedName{
+		Namespace: m.instance.Namespace,
+		Name:      m.instance.Spec.Token.SecretKeyRef.Name,
+	}
+	token, err := secretKeyRef(ctx, r.Client, nn, m.instance.Spec.Token.SecretKeyRef.Key)
 	if err != nil {
 		return err
 	}

--- a/controllers/project_controller.go
+++ b/controllers/project_controller.go
@@ -109,24 +109,12 @@ func (r *ProjectReconciler) addFinalizer(ctx context.Context, instance *appv1alp
 	return r.Update(ctx, instance)
 }
 
-func (r *ProjectReconciler) getToken(ctx context.Context, instance *appv1alpha2.Project) (string, error) {
-	secretName := instance.Spec.Token.SecretKeyRef.Name
-	secretKey := instance.Spec.Token.SecretKeyRef.Key
-
-	objectKey := types.NamespacedName{
-		Namespace: instance.Namespace,
-		Name:      secretName,
-	}
-	token, err := secretKeyRef(ctx, r.Client, objectKey, secretKey)
-	if err != nil {
-		return "", err
-	}
-
-	return token, nil
-}
-
 func (r *ProjectReconciler) getTerraformClient(ctx context.Context, p *projectInstance) error {
-	token, err := r.getToken(ctx, &p.instance)
+	nn := types.NamespacedName{
+		Namespace: p.instance.Namespace,
+		Name:      p.instance.Spec.Token.SecretKeyRef.Name,
+	}
+	token, err := secretKeyRef(ctx, r.Client, nn, p.instance.Spec.Token.SecretKeyRef.Key)
 	if err != nil {
 		return err
 	}

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -134,24 +134,12 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *WorkspaceReconciler) getToken(ctx context.Context, instance *appv1alpha2.Workspace) (string, error) {
-	secretName := instance.Spec.Token.SecretKeyRef.Name
-	secretKey := instance.Spec.Token.SecretKeyRef.Key
-
-	objectKey := types.NamespacedName{
-		Namespace: instance.Namespace,
-		Name:      secretName,
-	}
-	token, err := secretKeyRef(ctx, r.Client, objectKey, secretKey)
-	if err != nil {
-		return "", err
-	}
-
-	return token, nil
-}
-
 func (r *WorkspaceReconciler) getTerraformClient(ctx context.Context, w *workspaceInstance) error {
-	token, err := r.getToken(ctx, &w.instance)
+	nn := types.NamespacedName{
+		Namespace: w.instance.Namespace,
+		Name:      w.instance.Spec.Token.SecretKeyRef.Name,
+	}
+	token, err := secretKeyRef(ctx, r.Client, nn, w.instance.Spec.Token.SecretKeyRef.Key)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

This PR removes the `getToken` methods and instead switches to the `secretKeyRef` function.

#### Tests

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8691664113
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8691666287

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
