### PR TITLE
🧹 Remove `getValueFrom` method

### DIFF
--- a/api/v1alpha2/workspace_validation.go
+++ b/api/v1alpha2/workspace_validation.go
@@ -463,6 +463,10 @@ func (w *Workspace) validateSpecProject() field.ErrorList {
 //
 // + EnvironmentVariables names duplicate: spec.environmentVariables[].name
 // + TerraformVariables names duplicate: spec.terraformVariables[].name
+//
+// + EnvironmentVariables only one of the values from ConfigMapKeyRef or SecretKeyRef is allowed
+// + TerraformVariables only one of the values from ConfigMapKeyRef or SecretKeyRef is allowed
+//
 // + Tags duplicate: spec.tags[]
 //
 // + Invalid CR cannot be deleted until it is fixed -- need to discuss if we want to do something about it

--- a/controllers/workspace_controller_variables.go
+++ b/controllers/workspace_controller_variables.go
@@ -180,9 +180,9 @@ func (r *WorkspaceReconciler) getVariablesByCategory(ctx context.Context, w *wor
 	}
 
 	for _, v := range instanceVariables {
-		var err error
 		value := v.Value
 		if v.ValueFrom != nil {
+			var err error
 			objectKey := types.NamespacedName{
 				Namespace: w.instance.Namespace,
 			}

--- a/controllers/workspace_controller_variables.go
+++ b/controllers/workspace_controller_variables.go
@@ -164,34 +164,6 @@ func (r *WorkspaceReconciler) deleteWorkspaceVariables(ctx context.Context, w *w
 	return nil
 }
 
-func (r *WorkspaceReconciler) getValueFrom(ctx context.Context, instance *appv1alpha2.Workspace, valueFrom *appv1alpha2.ValueFrom) (string, error) {
-	objectKey := types.NamespacedName{
-		Namespace: instance.Namespace,
-	}
-
-	cm := valueFrom.ConfigMapKeyRef
-	if cm != nil {
-		objectKey.Name = cm.Name
-		v, err := configMapKeyRef(ctx, r.Client, objectKey, cm.Key)
-		if err != nil {
-			return "", err
-		}
-		return v, nil
-	}
-
-	s := valueFrom.SecretKeyRef
-	if s != nil {
-		objectKey.Name = s.Name
-		v, err := secretKeyRef(ctx, r.Client, objectKey, s.Key)
-		if err != nil {
-			return "", err
-		}
-		return v, nil
-	}
-
-	return "", nil
-}
-
 // getVariablesByCategory returns a map of all instance variables by type.
 func (r *WorkspaceReconciler) getVariablesByCategory(ctx context.Context, w *workspaceInstance, category tfc.CategoryType) map[string]tfc.Variable {
 	variables := make(map[string]tfc.Variable)
@@ -211,7 +183,17 @@ func (r *WorkspaceReconciler) getVariablesByCategory(ctx context.Context, w *wor
 		var err error
 		value := v.Value
 		if v.ValueFrom != nil {
-			value, err = r.getValueFrom(ctx, &w.instance, v.ValueFrom)
+			objectKey := types.NamespacedName{
+				Namespace: w.instance.Namespace,
+			}
+			if cm := v.ValueFrom.ConfigMapKeyRef; cm != nil {
+				objectKey.Name = cm.Name
+				value, err = configMapKeyRef(ctx, r.Client, objectKey, cm.Key)
+			}
+			if s := v.ValueFrom.SecretKeyRef; s != nil {
+				objectKey.Name = s.Name
+				value, err = secretKeyRef(ctx, r.Client, objectKey, s.Key)
+			}
 			if err != nil {
 				w.log.Error(err, "Reconcile Variables", "msg", fmt.Sprintf("failed to get value for the variable %s", v.Name))
 				r.Recorder.Event(&w.instance, corev1.EventTypeWarning, "ReconcileVariables", "Failed to get value for a variable")


### PR DESCRIPTION
### Description

This PR removes the `getValueFrom` method and instead switches to the `configMapKeyRef` and `secretKeyRef` functions.

#### Tests

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8691753454
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8691755058

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
