### PR TITLE
🚀 Add `spec.terraformVariables` and `spec.environmentVariables` validation

### DIFF
--- a/api/v1alpha2/workspace_validation.go
+++ b/api/v1alpha2/workspace_validation.go
@@ -23,6 +23,8 @@ func (w *Workspace) ValidateSpec() error {
 	allErrs = append(allErrs, w.validateSpecRunTriggers()...)
 	allErrs = append(allErrs, w.validateSpecSSHKey()...)
 	allErrs = append(allErrs, w.validateSpecProject()...)
+	allErrs = append(allErrs, w.validateSpecTerraformVariables()...)
+	allErrs = append(allErrs, w.validateSpecEnvironmentVariables()...)
 
 	if len(allErrs) == 0 {
 		return nil
@@ -459,13 +461,114 @@ func (w *Workspace) validateSpecProject() field.ErrorList {
 	return allErrs
 }
 
+func validateSpecVariables(fp *field.Path, spec []Variable) field.ErrorList {
+	allErrs := field.ErrorList{}
+	d := make(map[string]struct{})
+
+	for i, v := range spec {
+		f := fp.Child(fmt.Sprintf("[%d]", i))
+
+		if _, ok := d[v.Name]; ok {
+			allErrs = append(allErrs, field.Duplicate(f.Child("Name"), v.Name))
+		}
+		d[v.Name] = struct{}{}
+
+		if v.Value == "" && v.ValueFrom == nil {
+			allErrs = append(allErrs, field.Invalid(
+				f,
+				"",
+				"at least one of Value or ValueFrom must be set",
+			))
+		}
+
+		if len(v.Value) > 0 && v.ValueFrom != nil {
+			allErrs = append(allErrs, field.Invalid(
+				f,
+				"",
+				"only one of the field Value or ValueFrom is allowed"),
+			)
+		}
+
+		if v.ValueFrom != nil {
+			f = f.Child("ValueFrom")
+			if v.ValueFrom.ConfigMapKeyRef == nil && v.ValueFrom.SecretKeyRef == nil {
+				allErrs = append(allErrs, field.Invalid(
+					f,
+					"",
+					"at least one of ConfigMapKeyRef or SecretKeyRef must be set",
+				))
+			}
+
+			if v.ValueFrom.ConfigMapKeyRef != nil && v.ValueFrom.SecretKeyRef != nil {
+				allErrs = append(allErrs, field.Invalid(
+					f,
+					"",
+					"only one of the field ConfigMapKeyRef or SecretKeyRef is allowed"),
+				)
+			}
+
+			if v.ValueFrom.ConfigMapKeyRef != nil {
+				if v.ValueFrom.ConfigMapKeyRef.Name == "" {
+					allErrs = append(allErrs, field.Invalid(
+						f.Child("ConfigMapKeyRef"),
+						"",
+						"Name must be set",
+					))
+				}
+				if v.ValueFrom.ConfigMapKeyRef.Key == "" {
+					allErrs = append(allErrs, field.Invalid(
+						f.Child("ConfigMapKeyRef"),
+						"",
+						"Key must be set",
+					))
+				}
+			}
+
+			if v.ValueFrom.SecretKeyRef != nil {
+				if v.ValueFrom.SecretKeyRef.Name == "" {
+					allErrs = append(allErrs, field.Invalid(
+						f.Child("SecretKeyRef"),
+						"",
+						"Name must be set",
+					))
+				}
+				if v.ValueFrom.SecretKeyRef.Key == "" {
+					allErrs = append(allErrs, field.Invalid(
+						f.Child("SecretKeyRef"),
+						"",
+						"Key must be set",
+					))
+				}
+			}
+		}
+	}
+
+	return allErrs
+}
+
+func (w *Workspace) validateSpecTerraformVariables() field.ErrorList {
+	allErrs := field.ErrorList{}
+	spec := w.Spec.TerraformVariables
+
+	if spec == nil {
+		return allErrs
+	}
+
+	return validateSpecVariables(field.NewPath("spec").Child("terraformVariables"), spec)
+}
+
+func (w *Workspace) validateSpecEnvironmentVariables() field.ErrorList {
+	allErrs := field.ErrorList{}
+	spec := w.Spec.EnvironmentVariables
+
+	if spec == nil {
+		return allErrs
+	}
+
+	return validateSpecVariables(field.NewPath("spec").Child("environmentVariables"), spec)
+}
+
 // TODO:Validation
-//
-// + EnvironmentVariables names duplicate: spec.environmentVariables[].name
-// + TerraformVariables names duplicate: spec.terraformVariables[].name
-//
-// + EnvironmentVariables only one of the values from ConfigMapKeyRef or SecretKeyRef is allowed
-// + TerraformVariables only one of the values from ConfigMapKeyRef or SecretKeyRef is allowed
 //
 // + Tags duplicate: spec.tags[]
 //

--- a/api/v1alpha2/workspace_validation_test.go
+++ b/api/v1alpha2/workspace_validation_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	tfc "github.com/hashicorp/go-tfe"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 func TestValidateWorkspaceSpecAgentPool(t *testing.T) {
@@ -906,6 +908,131 @@ func TestValidateWorkspaceSpecProject(t *testing.T) {
 	for n, c := range errorCases {
 		t.Run(n, func(t *testing.T) {
 			if errs := c.validateSpecProject(); len(errs) == 0 {
+				t.Error("Unexpected failure, at least one error is expected")
+			}
+		})
+	}
+}
+
+func TestValidateWorkspaceSpecVariables(t *testing.T) {
+	t.Parallel()
+
+	f := field.NewPath("spec")
+
+	successCases := map[string][]Variable{
+		"HasOnlyValue": {{
+			Name:  "name",
+			Value: "42",
+		}},
+		"HasOnlyValueFromConfigMapKeyRef": {{
+			Name: "name",
+			ValueFrom: &ValueFrom{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key:                  "this",
+					LocalObjectReference: corev1.LocalObjectReference{Name: "this"},
+				},
+			},
+		}},
+		"HasOnlyValueFromSecretKeySelector": {{
+			Name: "name",
+			ValueFrom: &ValueFrom{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key:                  "this",
+					LocalObjectReference: corev1.LocalObjectReference{Name: "this"},
+				},
+			},
+		}},
+	}
+
+	for n, c := range successCases {
+		t.Run(n, func(t *testing.T) {
+			if errs := validateSpecVariables(f.Child("terraformVariables"), c); len(errs) != 0 {
+				t.Errorf("Unexpected validation errors: %v", errs)
+			}
+			if errs := validateSpecVariables(f.Child("environmentVariables"), c); len(errs) != 0 {
+				t.Errorf("Unexpected validation errors: %v", errs)
+			}
+		})
+	}
+
+	errorCases := map[string][]Variable{
+		"HasDuplicateVariablesName": {
+			{
+				Name:  "name",
+				Value: "42",
+			},
+			{
+				Name:  "name",
+				Value: "42",
+			},
+		},
+		"HasValueAndValueFrom": {{
+			Name:  "name",
+			Value: "42",
+			ValueFrom: &ValueFrom{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key:                  "this",
+					LocalObjectReference: corev1.LocalObjectReference{Name: "this"},
+				},
+			},
+		}},
+		"HasEmptyValueFrom": {{
+			Name:      "name",
+			ValueFrom: &ValueFrom{},
+		}},
+		"HasValueFromConfigMapAndSecret": {{
+			Name: "name",
+			ValueFrom: &ValueFrom{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key:                  "this",
+					LocalObjectReference: corev1.LocalObjectReference{Name: "this"},
+				},
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key:                  "this",
+					LocalObjectReference: corev1.LocalObjectReference{Name: "this"},
+				},
+			},
+		}},
+		"HasValueFromConfigMapWithoutName": {{
+			Name: "name",
+			ValueFrom: &ValueFrom{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key: "this",
+				},
+			},
+		}},
+		"HasValueFromConfigMapWithoutKey": {{
+			Name: "name",
+			ValueFrom: &ValueFrom{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "this"},
+				},
+			},
+		}},
+		"HasValueFromSecretWithoutName": {{
+			Name: "name",
+			ValueFrom: &ValueFrom{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key: "this",
+				},
+			},
+		}},
+		"HasValueFromSecretWithoutKey": {{
+			Name: "name",
+			ValueFrom: &ValueFrom{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "this"},
+				},
+			},
+		}},
+	}
+
+	for n, c := range errorCases {
+		t.Run(n, func(t *testing.T) {
+			if errs := validateSpecVariables(f.Child("terraformVariables"), c); len(errs) == 0 {
+				t.Error("Unexpected failure, at least one error is expected")
+			}
+			if errs := validateSpecVariables(f.Child("environmentVariables"), c); len(errs) == 0 {
 				t.Error("Unexpected failure, at least one error is expected")
 			}
 		})


### PR DESCRIPTION
### Description

This PR adds `spec.terraformVariables.[*]` and `spec.environmentVariables.[*]` validation.

#### Tests

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8708636494
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/8708639276

### Usage Example

N/A.

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
