### PR TITLE
🚀 Add `--workspace-sync-period` CLI and corresponding `workspace.syncPeriod` Helm chart option

### DIFF
--- a/.changes/unreleased/FEATURES-391-20240424-100418.yaml
+++ b/.changes/unreleased/FEATURES-391-20240424-100418.yaml
@@ -1,0 +1,6 @@
+kind: FEATURES
+body: '`Workspace`: Add a new CLI option called `--workspace-sync-period` to set the
+  time interval for re-queuing Workspace resources once they are successfully reconciled.'
+time: 2024-04-24T10:04:18.078493+02:00
+custom:
+  PR: "391"

--- a/.changes/unreleased/FEATURES-391-20240424-100420.yaml
+++ b/.changes/unreleased/FEATURES-391-20240424-100420.yaml
@@ -1,0 +1,6 @@
+kind: FEATURES
+body: '`Helm`: Add a new value called `controllers.workspace.syncPeriod` to set the
+  CLI option `--workspace-sync-period`.'
+time: 2024-04-24T10:04:20.283556+02:00
+custom:
+  PR: "391"

--- a/charts/terraform-cloud-operator/README.md
+++ b/charts/terraform-cloud-operator/README.md
@@ -131,6 +131,7 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | controllers.agentPool.workers | int | `1` | The number of the Agent Pool controller workers. |
 | controllers.module.workers | int | `1` | The number of the Module controller workers. |
 | controllers.project.workers | int | `1` | The number of the Project controller workers. |
+| controllers.workspace.syncPeriod | string | `"5m"` | The minimum frequency at which watched workspace resources are reconciled. Format: 5s, 1m, etc. |
 | controllers.workspace.workers | int | `1` | The number of the Workspace controller workers. |
 | customCAcertificates | string | `""` | Custom Certificate Authority bundle to validate API TLS certificates. Expects a path to a CRT file containing concatenated certificates. |
 | imagePullSecrets | list | `[]` | Reference to one or more secrets essential for pulling container images. |

--- a/charts/terraform-cloud-operator/templates/deployment.yaml
+++ b/charts/terraform-cloud-operator/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
           - --module-workers={{ .Values.controllers.module.workers }}
           - --project-workers={{ .Values.controllers.project.workers }}
           - --workspace-workers={{ .Values.controllers.workspace.workers }}
+          - --workspace-sync-period={{ .Values.controllers.workspace.syncPeriod }}
           {{- range .Values.operator.watchedNamespaces }}
           - --namespace={{ . }}
           {{- end }}

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -75,6 +75,8 @@ controllers:
   workspace:
     # -- The number of the Workspace controller workers.
     workers: 1
+    # -- The minimum frequency at which watched workspace resources are reconciled. Format: 5s, 1m, etc.
+    syncPeriod: 5m
 
 # -- Custom Certificate Authority bundle to validate API TLS certificates. Expects a path to a CRT file containing concatenated certificates.
 customCAcertificates: ""

--- a/controllers/flags.go
+++ b/controllers/flags.go
@@ -1,0 +1,12 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package controllers
+
+import (
+	"time"
+)
+
+var (
+	WorkspaceSyncPeriod time.Duration
+)

--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -122,7 +122,7 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return requeueAfter(requeueRunStatusInterval)
 	}
 
-	return doNotRequeue()
+	return requeueAfter(WorkspaceSyncPeriod)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -70,9 +70,13 @@
 
   The `*-workers` options allow configuration of the number of concurrent workers available to process changes to resources. In certain cases increasing this number can improve performance.
 
-- **What does the `sync-period` option do?**
+- **What do the `*-sync-period` options do?**
 
-  The `--sync-period` option specifies the minimum frequency at which watched resources are reconciled. The synchronization period should be aligned with the number of managed Customer Resources. If the period is too low and the number of managed resources is too high, you may observe slowness in synchronization.
+  The `--sync-period` is a global operator option that specifies the minimum frequency at which all watched resources of all controllers are reconciled at once.
+
+  The `--workspace-sync-period` is a `Workspace` controller option that specifies the time interval for requeuing Workspace resources, ensuring they will be reconciled. This time is set individually per resource and it helps avoid spike of the resources to reconcile.
+
+  The controller synchronization period should be aligned with the number of managed Customer Resources. If the period is too low and the number of managed resources is too high, you may observe slowness in synchronization.
 
 - **Does the Operator work with Terraform Enterprise / TFE?**
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -78,6 +78,8 @@
 
   The controller synchronization period should be aligned with the number of managed Customer Resources. If the period is too low and the number of managed resources is too high, you may observe slowness in synchronization.
 
+  The value of `sync-period` should be higher than the value of `*-sync-period`.
+
 - **Does the Operator work with Terraform Enterprise / TFE?**
 
   Yes, the operator can be configured to use the custom TFE API endpoint using the [`operator.tfeAddress`](../charts/terraform-cloud-operator/README.md#values) value in the Helm chart. This value should be a valid URL including the protocol(`https://`), for the API of a Terraform Enterprise instance. Once the `operator.tfeAddress` attribute is set, the operator will no longer access the public Terraform Cloud, but rather the private Terraform Enterprise instance.

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 		"The minimum frequency at which watched workspace resources are reconciled. Format: 5s, 1m, etc.")
 
 	// TODO
+	// - Add validation that 'sync-period' has a higher value than '*-sync-period'
 	// - Add '*-sync-period' option for all controllers.
 	// - Add a new CLI option named 'status' (or consider a different name) that will print out the operator settings passed via flags.
 


### PR DESCRIPTION
### Description

This PR introduces a new CLI option called `--workspace-sync-period` along with a corresponding `controllers.workspace.syncPeriod` Helm chart option. It sets the time interval for re-queuing Workspace resources instead of pulling them all at once for reconciliation. This change helps distribute the workload of the Workspace controller more evenly, especially when managing a large number of resources.

### Usage Example

```console
$ helm upgrade demo hashicorp/terraform-cloud-operator --set controllers.workspace.syncPeriod=1m
```

### References

N/A.

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
