### PR TITLE
🐛 Fix an issue when the operator panics when running on API that does not support Projects

### DIFF
--- a/controllers/workspace_controller.go
+++ b/controllers/workspace_controller.go
@@ -401,8 +401,10 @@ func (r *WorkspaceReconciler) updateWorkspace(ctx context.Context, w *workspaceI
 			r.Recorder.Event(&w.instance, corev1.EventTypeWarning, "ReconcileWorkspace", "Failed to get organization")
 			return nil, err
 		}
-		w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("default project ID %s will be used", org.DefaultProject.ID))
-		updateOptions.Project = &tfc.Project{ID: org.DefaultProject.ID}
+		if org.DefaultProject != nil {
+			w.log.Info("Reconcile Workspace", "msg", fmt.Sprintf("default project ID %s will be used", org.DefaultProject.ID))
+			updateOptions.Project = &tfc.Project{ID: org.DefaultProject.ID}
+		}
 	}
 
 	return w.tfClient.Client.Workspaces.UpdateByID(ctx, w.instance.Status.WorkspaceID, updateOptions)


### PR DESCRIPTION
### Description

This PR fixes an issue when the Operator panics when running on API that does not support Projects.

### Usage Example

N/A.

### References

Fix: https://github.com/hashicorp/terraform-cloud-operator/issues/373

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
