### PR TITLE
🚀 Update Agent Pool requeue duration logic

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-420-20240611-101431.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-420-20240611-101431.yaml
@@ -1,5 +1,5 @@
 kind: ENHANCEMENTS
-body: '`AgentPool`: Update reconciliation logic to reduce the number of API calls. The controller will now reconcile custom resources after the cool down period if applicable, otherwise, the default timer is applied.'
+body: '`AgentPool`: Update reconciliation logic to reduce the number of API calls. The controller now reconciles custom resources after the cooldown period if applicable; otherwise, the default timer is applied.'
 time: 2024-06-11T10:14:31.124169+02:00
 custom:
     PR: "420"

--- a/.changes/unreleased/ENHANCEMENTS-420-20240611-101431.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-420-20240611-101431.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`AgentPool`: Update reconciliation logic to reduce the number of API calls. The controller will now reconcile custom resources after the cool down period if applicable, otherwise, the default timer is applied.'
+time: 2024-06-11T10:14:31.124169+02:00
+custom:
+    PR: "420"

--- a/controllers/agentpool_controller.go
+++ b/controllers/agentpool_controller.go
@@ -103,12 +103,12 @@ func (r *AgentPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	ap.log.Info("Agent Pool Controller", "msg", "successfully reconcilied agent pool")
 	r.Recorder.Eventf(&ap.instance, corev1.EventTypeNormal, "ReconcileAgentPool", "Successfully reconcilied agent pool ID %s", ap.instance.Status.AgentPoolID)
 
-	requeueDuration := AgentPoolSyncPeriod
+	// Re-queue custom resource after the cool down period if applicable.
 	if t := ap.remainCoolDownSeconds(); t > 0 {
-		requeueDuration = time.Duration(t) * time.Second
+		return requeueAfter(time.Duration(t) * time.Second)
 	}
 
-	return requeueAfter(requeueDuration)
+	return requeueAfter(AgentPoolSyncPeriod)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/agentpool_controller.go
+++ b/controllers/agentpool_controller.go
@@ -104,7 +104,7 @@ func (r *AgentPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	r.Recorder.Eventf(&ap.instance, corev1.EventTypeNormal, "ReconcileAgentPool", "Successfully reconcilied agent pool ID %s", ap.instance.Status.AgentPoolID)
 
 	// Re-queue custom resource after the cool down period if applicable.
-	if t := ap.remainCoolDownSeconds(); t > 0 {
+	if t := ap.coolDownSecondsRemaining(); t > 0 {
 		return requeueAfter(time.Duration(t) * time.Second)
 	}
 

--- a/controllers/agentpool_controller_autoscaling.go
+++ b/controllers/agentpool_controller_autoscaling.go
@@ -159,9 +159,9 @@ func (r *AgentPoolReconciler) scaleAgentDeployment(ctx context.Context, ap *agen
 	return r.Client.Update(ctx, &deployment)
 }
 
-// remainCoolDownSeconds returns the remaining seconds in the Cool Down stage.
+// coolDownSecondsRemaining returns the remaining seconds in the Cool Down stage.
 // A negative value indicates expired Cool Down.
-func (a *agentPoolInstance) remainCoolDownSeconds() int {
+func (a *agentPoolInstance) coolDownSecondsRemaining() int {
 	if s := a.instance.Status.AgentDeploymentAutoscalingStatus; s != nil && s.LastScalingEvent != nil {
 		lastScalingEventSeconds := int(time.Since(s.LastScalingEvent.Time).Seconds())
 		cooldownPeriodSeconds := int(*a.instance.Spec.AgentDeploymentAutoscaling.CooldownPeriodSeconds)
@@ -178,7 +178,7 @@ func (r *AgentPoolReconciler) reconcileAgentAutoscaling(ctx context.Context, ap 
 
 	ap.log.Info("Reconcile Agent Autoscaling", "msg", "new reconciliation event")
 
-	if ap.remainCoolDownSeconds() > 0 {
+	if ap.coolDownSecondsRemaining() > 0 {
 		ap.log.Info("Reconcile Agent Autoscaling", "msg", "autoscaler is within the cooldown period, skipping")
 		return nil
 	}


### PR DESCRIPTION
### Description

The `AgentPool` controller re-queues instances every 30 seconds by default even if those that are in the Cool Down period stage and no actions will be taken. This PR changes this logic and instances will be re-queued after the Cool Down period if applicable, otherwise, the default timer is applied.

#### Tests

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/9462052652
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/9462053898
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/9462055264
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/9462056435

### Usage Example

N/A.

### References

- Depends on: https://github.com/hashicorp/terraform-cloud-operator/pull/421

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
