### PR TITLE
Remove module/workspace name labels from output ConfigMaps

### DIFF
--- a/.changes/unreleased/BUG FIXES-423-20240606-173809.yaml
+++ b/.changes/unreleased/BUG FIXES-423-20240606-173809.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`Module`: Fix an issue where the controller cannot create ConfigMap and Secret for outputs when a Module custom resource `metadata.name` is longer than 63 characters. This issue occurs because the controller uses the custom resource name as the value for the ModuleName label in ConfigMap and Secret. The `ModuleName` label has been removed."'
+time: 2024-06-06T17:38:09.448477231-05:00
+custom:
+    PR: "423"

--- a/.changes/unreleased/BUG FIXES-423-20240606-173823.yaml
+++ b/.changes/unreleased/BUG FIXES-423-20240606-173823.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`Workspace`: Fix an issue where the controller cannot create ConfigMap and Secret for outputs when a Workspace custom resource `metadata.name` is longer than 63 characters. This issue occurs because the controller uses the custom resource name as the value for the `workspaceName` label in ConfigMap and Secret. The `workspaceName` label has been removed.'
+time: 2024-06-06T17:38:23.364657771-05:00
+custom:
+    PR: "423"

--- a/controllers/module_controller_outputs.go
+++ b/controllers/module_controller_outputs.go
@@ -96,7 +96,6 @@ func (r *ModuleReconciler) setOutputs(ctx context.Context, m *moduleInstance) er
 	}
 	labels := map[string]string{
 		"workspaceID": m.instance.Status.WorkspaceID,
-		"ModuleName":  m.instance.ObjectMeta.Name,
 	}
 
 	// update ConfigMap output

--- a/controllers/workspace_controller_outputs.go
+++ b/controllers/workspace_controller_outputs.go
@@ -110,7 +110,6 @@ func (r *WorkspaceReconciler) setOutputs(ctx context.Context, w *workspaceInstan
 	}
 	labels := map[string]string{
 		"workspaceID":   w.instance.Status.WorkspaceID,
-		"workspaceName": w.instance.Spec.Name,
 	}
 
 	// update ConfigMap output


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

### Description

<!---
Please describe your changes in detail.
--->

Labels on Kubernetes resources can only be 63 characters long. If the workspace/module name is longer than that, the controllers will go into an error loop. This PR truncates the ConfigMap labels at 63 characters.

I'll be the first to admit this is not a very good solution, and I am open to an alternative. I just didn't want to propose a breaking change without getting some input.

Alternatives:
- Make the labels into annotations instead.
- Do away with the labels entirely.
- Make any or all of the above configurable using CLI flags. 

### Usage Example

<!---
Please provide a usage example if you have implemented a new feature.
--->

N/A

### References

<!---
Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
For example:
 - Fixes: GH-0000
-->

- Fixes: #418 

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
