### PR TITLE
🌱 Bump kube-rbac-proxy from 0.17.0 to 0.18.0

### DIFF
--- a/.changes/unreleased/DEPENDENCIES-424-20240606-103613.yaml
+++ b/.changes/unreleased/DEPENDENCIES-424-20240606-103613.yaml
@@ -1,0 +1,5 @@
+kind: DEPENDENCIES
+body: Bump `kube-rbac-proxy` from 0.17.0 to 0.18.0.
+time: 2024-06-06T10:36:13.510219+02:00
+custom:
+    PR: "424"

--- a/charts/terraform-cloud-operator/README.md
+++ b/charts/terraform-cloud-operator/README.md
@@ -144,7 +144,7 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | imagePullSecrets | list | `[]` | Reference to one or more secrets essential for pulling container images. |
 | kubeRbacProxy.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | kubeRbacProxy.image.repository | string | `"quay.io/brancz/kube-rbac-proxy"` | Image repository. |
-| kubeRbacProxy.image.tag | string | `"v0.17.0"` | Image tag. |
+| kubeRbacProxy.image.tag | string | `"v0.18.0"` | Image tag. |
 | kubeRbacProxy.resources.limits.cpu | string | `"500m"` | Limits as a maximum amount of CPU to be used by a container. |
 | kubeRbacProxy.resources.limits.memory | string | `"128Mi"` | Limits as a maximum amount of memory to be used by a container. |
 | kubeRbacProxy.resources.requests.cpu | string | `"50m"` | Guaranteed minimum amount of CPU to be used by a container. |

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -47,7 +47,7 @@ kubeRbacProxy:
     # -- Image pull policy.
     pullPolicy: IfNotPresent
     # -- Image tag.
-    tag: v0.17.0
+    tag: v0.18.0
 
   resources:
     limits:


### PR DESCRIPTION
### Description

Bump kube-rbac-proxy from `0.17.0` to `0.18.0`.

#### Tests

- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/9397711209
- https://github.com/hashicorp/terraform-cloud-operator/actions/runs/9397712317

### Usage Example

N/A.

### References

- https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.18.0

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
