### PR TITLE
Handle API pagination

### DIFF
--- a/.changes/unreleased/BUG FIXES-426-20240606-184719.yaml
+++ b/.changes/unreleased/BUG FIXES-426-20240606-184719.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`Project`: Fix an issue where calls to paginated API endpoints were only fetching the first page of results.'
+time: 2024-06-06T18:47:19.418960132-05:00
+custom:
+    PR: "426"

--- a/.changes/unreleased/BUG FIXES-426-20240606-184749.yaml
+++ b/.changes/unreleased/BUG FIXES-426-20240606-184749.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`AgentPool`: Fix an issue where calls to paginated API endpoints were only fetching the first page of results.'
+time: 2024-06-06T18:47:49.567157973-05:00
+custom:
+    PR: "426"

--- a/.changes/unreleased/BUG FIXES-426-20240606-184753.yaml
+++ b/.changes/unreleased/BUG FIXES-426-20240606-184753.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: '`Workspace`: Fix an issue where calls to paginated API endpoints were only fetching the first page of results.'
+time: 2024-06-06T18:47:53.667721493-05:00
+custom:
+    PR: "426"

--- a/controllers/project_controller_team_access.go
+++ b/controllers/project_controller_team_access.go
@@ -64,7 +64,12 @@ func (r *ProjectReconciler) getInstanceTeamAccess(ctx context.Context, p *projec
 func (r *ProjectReconciler) getWorkspaceTeamAccess(ctx context.Context, p *projectInstance) (map[string]*tfc.TeamProjectAccess, error) {
 	o := map[string]*tfc.TeamProjectAccess{}
 
-	listOpts := tfc.TeamProjectAccessListOptions{ProjectID: p.instance.Status.ID}
+	listOpts := tfc.TeamProjectAccessListOptions{
+		ProjectID: p.instance.Status.ID,
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
+	}
 	for {
 		t, err := p.tfClient.Client.TeamProjectAccess.List(ctx, listOpts)
 		if err != nil {
@@ -93,6 +98,9 @@ func (r *ProjectReconciler) getTeams(ctx context.Context, p *projectInstance) (m
 
 	listOpts := &tfc.TeamListOptions{
 		Names: fTeams,
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
 	}
 	for {
 		tl, err := p.tfClient.Client.Teams.List(ctx, p.instance.Spec.Organization, listOpts)

--- a/controllers/workspace_controller_agents.go
+++ b/controllers/workspace_controller_agents.go
@@ -15,6 +15,9 @@ func (r *WorkspaceReconciler) getAgentPoolIDByName(ctx context.Context, w *works
 
 	listOpts := &tfc.AgentPoolListOptions{
 		Query: agentPoolName,
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
 	}
 	for {
 		agentPoolIDs, err := w.tfClient.Client.AgentPools.List(ctx, w.instance.Spec.Organization, listOpts)

--- a/controllers/workspace_controller_notifications.go
+++ b/controllers/workspace_controller_notifications.go
@@ -54,6 +54,9 @@ func (r *WorkspaceReconciler) getOrgMembers(ctx context.Context, w *workspaceIns
 	}
 	listOpts := &tfc.OrganizationMembershipListOptions{
 		Emails: e,
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
 	}
 	for {
 		members, err := w.tfClient.Client.OrganizationMemberships.List(ctx, w.instance.Spec.Organization, listOpts)
@@ -112,7 +115,11 @@ func (r *WorkspaceReconciler) getInstanceNotifications(ctx context.Context, w *w
 func (r *WorkspaceReconciler) getWorkspaceNotifications(ctx context.Context, w *workspaceInstance) ([]tfc.NotificationConfiguration, error) {
 	var o []tfc.NotificationConfiguration
 
-	listOpts := &tfc.NotificationConfigurationListOptions{}
+	listOpts := &tfc.NotificationConfigurationListOptions{
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
+	}
 	for {
 		wn, err := w.tfClient.Client.NotificationConfigurations.List(ctx, w.instance.Status.WorkspaceID, listOpts)
 		if err != nil {

--- a/controllers/workspace_controller_outputs.go
+++ b/controllers/workspace_controller_outputs.go
@@ -82,15 +82,28 @@ func (r *WorkspaceReconciler) setOutputs(ctx context.Context, w *workspaceInstan
 		return fmt.Errorf("secret %s is in use by different object thus it cannot be used to store outputs", oName)
 	}
 
-	outputs, err := w.tfClient.Client.StateVersions.ListOutputs(ctx, workspace.CurrentStateVersion.ID, &tfc.StateVersionOutputsListOptions{})
-	if err != nil {
-		w.log.Error(err, "Reconcile Outputs", "mgs", fmt.Sprintf("failed to list outputs for state version %q", workspace.CurrentStateVersion.ID))
-		return err
+	opts := &tfc.StateVersionOutputsListOptions{
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
+	}
+	var outputs []*tfc.StateVersionOutput
+	for {
+		resp, err := w.tfClient.Client.StateVersions.ListOutputs(ctx, workspace.CurrentStateVersion.ID, opts)
+		if err != nil {
+			w.log.Error(err, "Reconcile Outputs", "mgs", fmt.Sprintf("failed to list outputs for state version %q", workspace.CurrentStateVersion.ID))
+			return err
+		}
+		outputs = append(outputs, resp.Items...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.PageNumber = resp.NextPage
 	}
 
 	nonSensitiveOutput := make(map[string]string)
 	sensitiveOutput := make(map[string][]byte)
-	for _, o := range outputs.Items {
+	for _, o := range outputs {
 		out, err := formatOutput(o)
 		if err != nil {
 			w.log.Error(err, "Reconcile Outputs", "mgs", fmt.Sprintf("failed to marshal JSON for %q", o.Name))

--- a/controllers/workspace_controller_projects.go
+++ b/controllers/workspace_controller_projects.go
@@ -15,6 +15,9 @@ func (r *WorkspaceReconciler) getProjectIDByName(ctx context.Context, w *workspa
 
 	listOpts := &tfc.ProjectListOptions{
 		Name: projectName,
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
 	}
 	for {
 		projectIDs, err := w.tfClient.Client.Projects.List(ctx, w.instance.Spec.Organization, listOpts)

--- a/controllers/workspace_controller_remote_state_sharing.go
+++ b/controllers/workspace_controller_remote_state_sharing.go
@@ -15,7 +15,11 @@ import (
 func (r *WorkspaceReconciler) getWorkspaces(ctx context.Context, w *workspaceInstance) (map[string]string, error) {
 	o := make(map[string]string)
 
-	listOpts := &tfc.WorkspaceListOptions{}
+	listOpts := &tfc.WorkspaceListOptions{
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
+	}
 	for {
 		ws, err := w.tfClient.Client.Workspaces.List(ctx, w.instance.Spec.Organization, listOpts)
 		if err != nil {

--- a/controllers/workspace_controller_run_tasks.go
+++ b/controllers/workspace_controller_run_tasks.go
@@ -112,7 +112,11 @@ func (r *WorkspaceReconciler) getInstanceRunTasks(ctx context.Context, w *worksp
 
 	rl := make(map[string]string)
 	if hasRunTaskName(w) {
-		listOpts := &tfc.RunTaskListOptions{}
+		listOpts := &tfc.RunTaskListOptions{
+			ListOptions: tfc.ListOptions{
+				PageSize: maxPageSize,
+			},
+		}
 		for {
 			rt, err := w.tfClient.Client.RunTasks.List(ctx, w.instance.Spec.Organization, listOpts)
 			if err != nil {
@@ -146,7 +150,11 @@ func (r *WorkspaceReconciler) getInstanceRunTasks(ctx context.Context, w *worksp
 func (r *WorkspaceReconciler) getWorkspaceRunTasks(ctx context.Context, w *workspaceInstance) (map[string]*tfc.WorkspaceRunTask, error) {
 	o := map[string]*tfc.WorkspaceRunTask{}
 
-	listOpts := &tfc.WorkspaceRunTaskListOptions{}
+	listOpts := &tfc.WorkspaceRunTaskListOptions{
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
+	}
 	for {
 		wrt, err := w.tfClient.Client.WorkspaceRunTasks.List(ctx, w.instance.Status.WorkspaceID, listOpts)
 		if err != nil {

--- a/controllers/workspace_controller_run_triggers.go
+++ b/controllers/workspace_controller_run_triggers.go
@@ -42,6 +42,9 @@ func (r *WorkspaceReconciler) getRunTriggersWorkspace(ctx context.Context, w *wo
 	listOpts := &tfc.RunTriggerListOptions{
 		RunTriggerType: tfc.RunTriggerInbound,
 		Include:        []tfc.RunTriggerIncludeOpt{tfc.RunTriggerSourceable},
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
 	}
 	for {
 		runTriggers, err := w.tfClient.Client.RunTriggers.List(ctx, w.instance.Status.WorkspaceID, listOpts)

--- a/controllers/workspace_controller_sshkey.go
+++ b/controllers/workspace_controller_sshkey.go
@@ -13,7 +13,11 @@ import (
 func (r *WorkspaceReconciler) getSSHKeyIDByName(ctx context.Context, w *workspaceInstance) (string, error) {
 	SSHKeyName := w.instance.Spec.SSHKey.Name
 
-	listOpts := &tfc.SSHKeyListOptions{}
+	listOpts := &tfc.SSHKeyListOptions{
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
+	}
 	for {
 		SSHKeys, err := w.tfClient.Client.SSHKeys.List(ctx, w.instance.Spec.Organization, listOpts)
 		if err != nil {

--- a/controllers/workspace_controller_team_access.go
+++ b/controllers/workspace_controller_team_access.go
@@ -76,7 +76,12 @@ func (r *WorkspaceReconciler) getInstanceTeamAccess(ctx context.Context, w *work
 func (r *WorkspaceReconciler) getWorkspaceTeamAccess(ctx context.Context, w *workspaceInstance) (map[string]*tfc.TeamAccess, error) {
 	o := map[string]*tfc.TeamAccess{}
 
-	listOpts := &tfc.TeamAccessListOptions{WorkspaceID: w.instance.Status.WorkspaceID}
+	listOpts := &tfc.TeamAccessListOptions{
+		WorkspaceID: w.instance.Status.WorkspaceID,
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
+	}
 	for {
 		t, err := w.tfClient.Client.TeamAccess.List(ctx, listOpts)
 		if err != nil {
@@ -105,6 +110,9 @@ func (r *WorkspaceReconciler) getTeams(ctx context.Context, w *workspaceInstance
 
 	listOpts := &tfc.TeamListOptions{
 		Names: fTeams,
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
 	}
 	for {
 		tl, err := w.tfClient.Client.Teams.List(ctx, w.instance.Spec.Organization, listOpts)

--- a/controllers/workspace_controller_variables.go
+++ b/controllers/workspace_controller_variables.go
@@ -140,7 +140,11 @@ func (r *WorkspaceReconciler) getWorkspaceVariables(ctx context.Context, w *work
 	var o []*tfc.Variable
 
 	w.log.Info("Reconcile Variables", "msg", "getting workspace variables")
-	listOpts := &tfc.VariableListOptions{}
+	listOpts := &tfc.VariableListOptions{
+		ListOptions: tfc.ListOptions{
+			PageSize: maxPageSize,
+		},
+	}
 	for {
 		v, err := w.tfClient.Client.Variables.List(ctx, w.instance.Status.WorkspaceID, listOpts)
 		if err != nil {


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

### Description

We encountered a bug where some workspaces that should have had run triggers added by the operator did not have them. We suspected it was due to the controller [not handling pagination](https://github.com/hashicorp/terraform-cloud-operator/blob/e7e491c3685dd445d17090fb667a8935f51e3588/controllers/workspace_controller_run_triggers.go#L31). I'm no longer sure that's the source of our bug, but it still seems reasonable that any calls to a Terraform Cloud API endpoint that is paginated should handle that pagination.

<!---
Please describe your changes in detail.
--->

### Usage Example

<!---
Please provide a usage example if you have implemented a new feature.
--->

N/A

### References

<!---
Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
For example:
 - Fixes: GH-0000
-->

N/A

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
