### PR TITLE
🤖 Add repo checkout step to PR labeler workflow

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,34 +1,65 @@
 api:
-- 'api/**/*.go'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'api/**/*.go'
 
 controller:
-- 'controllers/*.go'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'controllers/*.go'
 
 crd:
-- 'config/crd/bases/*.yaml'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'config/crd/bases/*.yaml'
 
 dependencies:
-- 'go.mod'
-- 'go.sum'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'go.mod'
+      - 'go.sum'
 
 documentation:
-- any: ['*.md']
-  all: ['!CHANGELOG.md']
-- 'charts/**/*.md'
-- 'docs/*.md'
+- all:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '*.md'
+      - 'charts/**/*.md'
+      - 'docs/*.md'
+    - all-globs-to-all-files:
+      - '!CHANGELOG.md'
 
 github_actions:
-- '**/workflows/*.yaml'
-- '**/workflows/*.yml'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/workflows/*.yaml'
+      - '**/workflows/*.yml'
 
 golang:
-- '**/*.go'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*.go'
 
 helm-chart:
-- 'charts/**/*.yaml'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'charts/**/*.yaml'
 
 release:
-- 'version/VERSION'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'version/VERSION'
 
 test:
-- '**/*_test.go'
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - '**/*_test.go'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,9 +1,6 @@
 name: "PR Labeler"
 
 on:
- pull_request:
-  branches:
-   - main
  pull_request_target:
    branches:
    - main

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,12 +1,9 @@
 name: "PR Labeler"
 
 on:
- pull_request:
-  branches:
-   - main
- pull_request_target:
-   branches:
-   - main
+  pull_request_target:
+    branches:
+    - main
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,6 +13,9 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
     - name: Label Pull Request
       uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
       with:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,9 @@
 name: "PR Labeler"
 
 on:
+ pull_request:
+  branches:
+   - main
  pull_request_target:
    branches:
    - main


### PR DESCRIPTION
### Description

PR Labeler workflow is [failing](https://github.com/hashicorp/terraform-cloud-operator/actions/runs/9461050046/job/26061014339?pr=421) after [action updates](https://github.com/hashicorp/terraform-cloud-operator/pull/406). This PR introduces a fix.

### Usage Example

N/A.

### References

- https://github.com/actions/labeler?tab=readme-ov-file#using-configuration-path-input-together-with-the-actionscheckout-action

### Community Note

* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
