### PR TITLE
🚀Add Default `securityContext` and Ability to Configure it

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-432-20240703-130920.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-432-20240703-130920.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: '`Helm Chart`: Add the ability to configure the security context of the Deployment pod and containers.'
+time: 2024-07-03T13:09:20.971299+02:00
+custom:
+    PR: "432"

--- a/charts/terraform-cloud-operator/README.md
+++ b/charts/terraform-cloud-operator/README.md
@@ -149,6 +149,7 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | kubeRbacProxy.resources.limits.memory | string | `"128Mi"` | Limits as a maximum amount of memory to be used by a container. |
 | kubeRbacProxy.resources.requests.cpu | string | `"50m"` | Guaranteed minimum amount of CPU to be used by a container. |
 | kubeRbacProxy.resources.requests.memory | string | `"64Mi"` | Guaranteed minimum amount of memory to be used by a container. |
+| kubeRbacProxy.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
 | operator.image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | operator.image.repository | string | `"hashicorp/terraform-cloud-operator"` | Image repository. |
 | operator.image.tag | string | `""` | Image tag. Defaults to `.Chart.AppVersion`. |
@@ -156,8 +157,10 @@ For a more detailed explanation, please refer to the [FAQ](../../docs/faq.md#gen
 | operator.resources.limits.memory | string | `"128Mi"` | Limits as a maximum amount of memory to be used by a container. |
 | operator.resources.requests.cpu | string | `"50m"` | Guaranteed minimum amount of CPU to be used by a container. |
 | operator.resources.requests.memory | string | `"64Mi"` | Guaranteed minimum amount of memory to be used by a container. |
+| operator.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |
 | operator.skipTLSVerify | bool | `false` | Whether or not to ignore TLS certification warnings. |
 | operator.syncPeriod | string | `"5m"` | The minimum frequency at which watched resources are reconciled. Format: `5s`, `1m`, etc. |
 | operator.tfeAddress | string | `""` | The API URL of a Terraform Enterprise instance. |
 | operator.watchedNamespaces | list | `[]` | List of namespaces the controllers should watch. |
 | replicaCount | int | `2` | The number of Operator replicas. |
+| securityContext | object | `{"runAsNonRoot":true}` | Deployment pod security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/). |

--- a/charts/terraform-cloud-operator/templates/deployment.yaml
+++ b/charts/terraform-cloud-operator/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
           resources:
             {{- toYaml .Values.operator.resources | nindent 12 }}
           securityContext:
-            allowPrivilegeEscalation: false
+            {{- toYaml .Values.operator.securityContext | nindent 12 }}
           volumeMounts:
           {{- if .Values.customCAcertificates }}
           - name: ca-certificates
@@ -93,10 +93,10 @@ spec:
           resources:
             {{- toYaml .Values.kubeRbacProxy.resources | nindent 12 }}
           securityContext:
-            allowPrivilegeEscalation: false
+            {{- toYaml .Values.kubeRbacProxy.securityContext | nindent 12 }}
       serviceAccountName: {{ .Release.Name }}-controller-manager
       securityContext:
-        runAsNonRoot: true
+        {{- toYaml .Values.securityContext | nindent 12 }}
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:

--- a/charts/terraform-cloud-operator/templates/deployment.yaml
+++ b/charts/terraform-cloud-operator/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
             {{- toYaml .Values.kubeRbacProxy.securityContext | nindent 12 }}
       serviceAccountName: {{ .Release.Name }}-controller-manager
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 12 }}
+        {{- toYaml .Values.securityContext | nindent 8 }}
       terminationGracePeriodSeconds: 10
       volumes:
       - configMap:

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -7,7 +7,7 @@ imagePullSecrets: []
 # -- The number of Operator replicas.
 replicaCount: 2
 
-# -- Security Context to Deployment
+# -- Deployment pod security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
 securityContext:
   runAsNonRoot: true
 
@@ -32,7 +32,7 @@ operator:
       # -- Guaranteed minimum amount of memory to be used by a container.
       memory: 64Mi
 
-  # -- Security Context to manager container
+  # -- Container security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -62,7 +62,7 @@ kubeRbacProxy:
     # -- Image tag.
     tag: v0.18.0
 
-  # -- Security Context to kube-rbac-proxy container
+  # -- Container security context. More information in [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -10,6 +10,10 @@ replicaCount: 2
 # -- Security Context to Deployment
 securityContext:
   runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 2000
+  seccompProfile:
+    type: RuntimeDefault
 
 # Operator-global options.
 operator:
@@ -34,7 +38,15 @@ operator:
 
   # -- Security Context to manager container
   securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
     allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
 
   # -- The minimum frequency at which watched resources are reconciled. Format: `5s`, `1m`, etc.
   syncPeriod: 5m
@@ -59,7 +71,15 @@ kubeRbacProxy:
 
   # -- Security Context to kube-rbac-proxy container
   securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
     allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
 
   resources:
     limits:

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -7,6 +7,10 @@ imagePullSecrets: []
 # -- The number of Operator replicas.
 replicaCount: 2
 
+# -- Security Context to Deployment
+securityContext:
+  runAsNonRoot: true
+
 # Operator-global options.
 operator:
   image:
@@ -28,6 +32,10 @@ operator:
       # -- Guaranteed minimum amount of memory to be used by a container.
       memory: 64Mi
 
+  # -- Security Context to manager container
+  securityContext:
+    allowPrivilegeEscalation: false
+
   # -- The minimum frequency at which watched resources are reconciled. Format: `5s`, `1m`, etc.
   syncPeriod: 5m
 
@@ -48,6 +56,10 @@ kubeRbacProxy:
     pullPolicy: IfNotPresent
     # -- Image tag.
     tag: v0.18.0
+
+  # -- Security Context to kube-rbac-proxy container
+  securityContext:
+    allowPrivilegeEscalation: false
 
   resources:
     limits:

--- a/charts/terraform-cloud-operator/values.yaml
+++ b/charts/terraform-cloud-operator/values.yaml
@@ -10,10 +10,6 @@ replicaCount: 2
 # -- Security Context to Deployment
 securityContext:
   runAsNonRoot: true
-  runAsUser: 1000
-  fsGroup: 2000
-  seccompProfile:
-    type: RuntimeDefault
 
 # Operator-global options.
 operator:
@@ -38,10 +34,7 @@ operator:
 
   # -- Security Context to manager container
   securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
     allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
     capabilities:
       drop:
         - ALL
@@ -71,10 +64,7 @@ kubeRbacProxy:
 
   # -- Security Context to kube-rbac-proxy container
   securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
     allowPrivilegeEscalation: false
-    readOnlyRootFilesystem: true
     capabilities:
       drop:
         - ALL


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

### Description
Add default securityContext options. Exposes ability to configure securityContext for:
- manager container
- kube-rbac-proxy container
- entire pod

### Usage Example

`values.yaml`
```
securityContext:
  runAsNonRoot: true
```
```
operator:
  securityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop:
        - ALL
    seccompProfile:
      type: RuntimeDefault
```
```
kubeRbacProxy:
  securityContext:
    allowPrivilegeEscalation: false
    capabilities:
      drop:
        - ALL
    seccompProfile:
      type: RuntimeDefault
```

### References
N/A

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
