### PR TITLE
🚀 Add user interaction status PolicyChecked for HCP TF

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-703-20260220-101734.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-703-20260220-101734.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Support for PolicyChecked run status to help right  agent scale down
+time: 2026-02-20T10:17:34.39567-08:00
+custom:
+    PR: "703"

--- a/internal/controller/agentpool_controller_autoscaling.go
+++ b/internal/controller/agentpool_controller_autoscaling.go
@@ -27,6 +27,7 @@ var userInteractionRunStatuses = map[tfc.RunStatus]struct{}{
 	tfc.RunPostPlanAwaitingDecision: {},
 	tfc.RunPostPlanCompleted:        {},
 	tfc.RunPending:                  {},
+	tfc.RunPolicyChecked:            {},
 }
 
 // matchWildcardName checks if a given string matches a specified wildcard pattern.

--- a/internal/controller/agentpool_controller_autoscaling_test.go
+++ b/internal/controller/agentpool_controller_autoscaling_test.go
@@ -150,6 +150,18 @@ func TestPendingRuns(t *testing.T) {
 			expectedCount: 1,
 			expectError:   false,
 		},
+		{
+			name: "plan and apply runs that might have user interaction status PolicyChecked",
+			mockRuns: []*tfc.Run{
+				{ID: "run1", PlanOnly: true, Status: tfc.RunPending, Workspace: &tfc.Workspace{ID: "ws2"}},
+				{ID: "run2", PlanOnly: true, Status: tfc.RunPlanning, Workspace: &tfc.Workspace{ID: "ws2"}},
+				{ID: "run3", PlanOnly: true, Status: tfc.RunPlanning, Workspace: &tfc.Workspace{ID: "ws2"}},
+				{ID: "run4", PlanOnly: true, Status: tfc.RunPlanning, Workspace: &tfc.Workspace{ID: "ws2"}},
+				{ID: "run5", PlanOnly: true, Status: tfc.RunPolicyChecked, Workspace: &tfc.Workspace{ID: "ws2"}},
+			},
+			expectedCount: 3,
+			expectError:   false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!---
Please describe your changes to security controls in detail.
--->

### Description

We currently support all necessary user interaction statuses while scaling the agent pool. However, in a recent update to HCP TF policy sets there seems to be a scenario where a run may enter the `PolicyChecked` status when a policy set has execution mode set to `Platform Environment`. Hence we need to add support for this run status.

Steps to reproduce the scale down issue due to policy_checked status:
- Create a policy with Enforcement behaviour set to Soft Mandatory
- Create a new policy set with this policy and select Execution mode set to Platform Environment
- Make sure the policy set is enforced on your workspace
- Start a new run in your workspace
- Once the run reaches the policy_override status click on the Override and continue button
- Observe that the agents don’t scale down to min replicas

### Usage Example

<!---
Please provide a usage example if you have implemented a new feature.
--->

### References

<!---
Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
For example:
 - Fixes: GH-0000
-->

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
