### PR TITLE
🚀 Add smart deployment update logic with change detection

### DIFF
--- a/internal/controller/agentpool_controller_deployment.go
+++ b/internal/controller/agentpool_controller_deployment.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/url"
 
+	"github.com/google/go-cmp/cmp"
 	tfc "github.com/hashicorp/go-tfe"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -85,7 +86,7 @@ func (r *AgentPoolReconciler) createDeployment(ctx context.Context, ap *agentPoo
 }
 
 func (r *AgentPoolReconciler) updateDeployment(ctx context.Context, ap *agentPoolInstance, d *appsv1.Deployment) error {
-	ap.log.Info("Reconcile Agent Deployment", "mgs", "performing Deployment update")
+	ap.log.Info("Reconcile Agent Deployment", "msg", "reconciling Deployment update")
 	nd := agentPoolDeployment(ap)
 
 	err := controllerutil.SetControllerReference(&ap.instance, nd, r.Scheme)
@@ -103,14 +104,27 @@ func (r *AgentPoolReconciler) updateDeployment(ctx context.Context, ap *agentPoo
 		nd.Spec.Replicas = d.Spec.Replicas
 	}
 
-	// TODO:
-	// - Add logic to update the deployment only when it has changed
-	uerr := r.Client.Update(ctx, nd, &client.UpdateOptions{FieldManager: "hcp-terraform-operator"})
+	// Save current state for comparison
+	oldSpec := d.Spec
+	oldAnnotations := d.Annotations
+
+	// Apply desired state onto existing deployment (preserves ResourceVersion and other server-managed fields)
+	d.Spec = nd.Spec
+	d.Annotations = nd.Annotations
+
+	// Only update if something actually changed
+	if cmp.Equal(oldSpec, d.Spec) && cmp.Equal(oldAnnotations, d.Annotations) {
+		ap.log.Info("Reconcile Agent Deployment", "msg", "no changes detected, skipping update")
+		return nil
+	}
+
+	uerr := r.Client.Update(ctx, d, &client.UpdateOptions{FieldManager: "hcp-terraform-operator"})
 	if uerr != nil {
 		ap.log.Error(uerr, "Reconcile Agent Deployment", "msg", "Failed to update agent deployment")
 		r.Recorder.Event(&ap.instance, corev1.EventTypeWarning, "Deployment update failed", uerr.Error())
 		return uerr
 	}
+	ap.log.Info("Reconcile Agent Deployment", "msg", "successfully updated agent deployment")
 	return nil
 }
 

--- a/internal/controller/agentpool_controller_deployment_test.go
+++ b/internal/controller/agentpool_controller_deployment_test.go
@@ -1,0 +1,262 @@
+// Copyright IBM Corp. 2022, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+	tfc "github.com/hashicorp/go-tfe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appv1alpha2 "github.com/hashicorp/hcp-terraform-operator/api/v1alpha2"
+	"github.com/hashicorp/hcp-terraform-operator/internal/pointer"
+)
+
+func newTestAgentPoolInstance(name, namespace string) *agentPoolInstance {
+	return &agentPoolInstance{
+		instance: appv1alpha2.AgentPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				UID:       types.UID("test-uid"),
+			},
+			Spec: appv1alpha2.AgentPoolSpec{
+				Name:         name,
+				Organization: "test-org",
+				AgentDeployment: &appv1alpha2.AgentDeployment{
+					Replicas: pointer.PointerOf(int32(3)),
+				},
+			},
+			Status: appv1alpha2.AgentPoolStatus{
+				AgentPoolID: "apool-123",
+				AgentTokens: []*appv1alpha2.AgentAPIToken{
+					{Name: "test-token"},
+				},
+			},
+		},
+		log: logr.Discard(),
+		tfClient: func() HCPTerraformClient {
+			c, _ := tfc.NewClient(&tfc.Config{Token: "test-token"})
+			return HCPTerraformClient{Client: c}
+		}(),
+	}
+}
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = appv1alpha2.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+func TestUpdateDeployment_NoChangeSkipsUpdate(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance("test-pool", "default")
+	scheme := newTestScheme()
+
+	// Build the desired deployment to use as the "existing" one
+	existing := agentPoolDeployment(ap)
+	existing.ResourceVersion = "12345"
+	// Set owner reference as updateDeployment does
+	existing.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         "app.terraform.io/v1alpha2",
+			Kind:               "AgentPool",
+			Name:               ap.instance.Name,
+			UID:                ap.instance.UID,
+			Controller:         pointer.PointerOf(true),
+			BlockOwnerDeletion: pointer.PointerOf(true),
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		Build()
+
+	r := &AgentPoolReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := r.updateDeployment(context.Background(), ap, existing)
+	require.NoError(t, err)
+
+	// Verify the deployment was NOT updated by checking ResourceVersion is unchanged
+	var result appsv1.Deployment
+	err = c.Get(context.Background(), types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &result)
+	require.NoError(t, err)
+	assert.Equal(t, "12345", result.ResourceVersion)
+}
+
+func TestUpdateDeployment_SpecChangeTriggersUpdate(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance("test-pool", "default")
+	scheme := newTestScheme()
+
+	// Build the "existing" deployment with different replicas
+	existing := agentPoolDeployment(ap)
+	existing.ResourceVersion = "12345"
+	existing.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         "app.terraform.io/v1alpha2",
+			Kind:               "AgentPool",
+			Name:               ap.instance.Name,
+			UID:                ap.instance.UID,
+			Controller:         pointer.PointerOf(true),
+			BlockOwnerDeletion: pointer.PointerOf(true),
+		},
+	}
+	// Change replicas on the existing deployment so it differs from desired
+	existing.Spec.Replicas = pointer.PointerOf(int32(1))
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		Build()
+
+	r := &AgentPoolReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := r.updateDeployment(context.Background(), ap, existing)
+	require.NoError(t, err)
+
+	// Verify the deployment was updated — replicas should now be 3
+	var result appsv1.Deployment
+	err = c.Get(context.Background(), types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &result)
+	require.NoError(t, err)
+	assert.Equal(t, pointer.PointerOf(int32(3)), result.Spec.Replicas)
+}
+
+func TestUpdateDeployment_AnnotationChangeTriggersUpdate(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance("test-pool", "default")
+	scheme := newTestScheme()
+
+	// Build the "existing" deployment with different annotations
+	existing := agentPoolDeployment(ap)
+	existing.ResourceVersion = "12345"
+	existing.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         "app.terraform.io/v1alpha2",
+			Kind:               "AgentPool",
+			Name:               ap.instance.Name,
+			UID:                ap.instance.UID,
+			Controller:         pointer.PointerOf(true),
+			BlockOwnerDeletion: pointer.PointerOf(true),
+		},
+	}
+	// Change annotations on the existing deployment
+	existing.Annotations["extra-annotation"] = "old-value"
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		Build()
+
+	r := &AgentPoolReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := r.updateDeployment(context.Background(), ap, existing)
+	require.NoError(t, err)
+
+	// Verify annotations were updated (extra-annotation should be gone)
+	var result appsv1.Deployment
+	err = c.Get(context.Background(), types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &result)
+	require.NoError(t, err)
+	_, hasExtra := result.Annotations["extra-annotation"]
+	assert.False(t, hasExtra, "extra annotation should have been removed by update")
+}
+
+func TestUpdateDeployment_PreservesResourceVersion(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance("test-pool", "default")
+	scheme := newTestScheme()
+
+	existing := agentPoolDeployment(ap)
+	existing.ResourceVersion = "12345"
+	existing.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         "app.terraform.io/v1alpha2",
+			Kind:               "AgentPool",
+			Name:               ap.instance.Name,
+			UID:                ap.instance.UID,
+			Controller:         pointer.PointerOf(true),
+			BlockOwnerDeletion: pointer.PointerOf(true),
+		},
+	}
+	// Force a change so the update path is taken
+	existing.Spec.Replicas = pointer.PointerOf(int32(1))
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		Build()
+
+	r := &AgentPoolReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := r.updateDeployment(context.Background(), ap, existing)
+	require.NoError(t, err)
+
+	// The update should succeed because existing has ResourceVersion
+	var result appsv1.Deployment
+	err = c.Get(context.Background(), types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &result)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.ResourceVersion, "ResourceVersion should be preserved after update")
+}
+
+func TestAgentPoolDeployment_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance("test-pool", "default")
+
+	d1 := agentPoolDeployment(ap)
+	d2 := agentPoolDeployment(ap)
+
+	// Two calls with the same input should produce identical specs
+	assert.True(t, cmp.Equal(d1.Spec, d2.Spec), "agentPoolDeployment should produce deterministic output")
+	assert.True(t, cmp.Equal(d1.Annotations, d2.Annotations), "agentPoolDeployment annotations should be deterministic")
+}
+
+func TestAgentPoolDeployment_DefaultValues(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance("test-pool", "default")
+	ap.instance.Spec.AgentDeployment.Replicas = nil // use default
+
+	d := agentPoolDeployment(ap)
+
+	assert.Equal(t, pointer.PointerOf(int32(1)), d.Spec.Replicas, "should default to 1 replica")
+	assert.Equal(t, &agentTerminationGracePeriod, d.Spec.Template.Spec.TerminationGracePeriodSeconds, "should set 15min termination grace period")
+	assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, d.Spec.Strategy.Type)
+	assert.Equal(t, pointer.PointerOf(intstr.FromInt(0)), d.Spec.Strategy.RollingUpdate.MaxSurge)
+}

--- a/internal/controller/agentpool_controller_deployment_test.go
+++ b/internal/controller/agentpool_controller_deployment_test.go
@@ -4,30 +4,89 @@
 package controller
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
 	tfc "github.com/hashicorp/go-tfe"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appv1alpha2 "github.com/hashicorp/hcp-terraform-operator/api/v1alpha2"
+	"github.com/hashicorp/hcp-terraform-operator/internal/pointer"
 )
 
-func TestDecorateDeployment_MixedContainerEnvSets(t *testing.T) {
-	t.Parallel()
-
-	tfServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func newTestTFCServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/v2/ping" {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
 		w.WriteHeader(http.StatusNotFound)
 	}))
+}
+
+func newTestAgentPoolInstance(t *testing.T, name, namespace string) *agentPoolInstance {
+	t.Helper()
+
+	tfServer := newTestTFCServer()
+	t.Cleanup(tfServer.Close)
+
+	client, err := tfc.NewClient(&tfc.Config{
+		Address: tfServer.URL,
+		Token:   "test-token",
+	})
+	require.NoError(t, err)
+
+	return &agentPoolInstance{
+		instance: appv1alpha2.AgentPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				UID:       types.UID("test-uid"),
+			},
+			Spec: appv1alpha2.AgentPoolSpec{
+				Name:         name,
+				Organization: "test-org",
+				AgentDeployment: &appv1alpha2.AgentDeployment{
+					Replicas: pointer.PointerOf(int32(3)),
+				},
+			},
+			Status: appv1alpha2.AgentPoolStatus{
+				AgentPoolID: "apool-123",
+				AgentTokens: []*appv1alpha2.AgentAPIToken{
+					{Name: "test-token"},
+				},
+			},
+		},
+		log:      logr.Discard(),
+		tfClient: HCPTerraformClient{Client: client},
+	}
+}
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = appv1alpha2.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+func TestDecorateDeployment_MixedContainerEnvSets(t *testing.T) {
+	t.Parallel()
+
+	tfServer := newTestTFCServer()
 	defer tfServer.Close()
 
 	client, err := tfc.NewClient(&tfc.Config{
@@ -129,4 +188,202 @@ func countEnvVar(envs []corev1.EnvVar, name string) int {
 	}
 
 	return count
+}
+
+func TestUpdateDeployment_NoChangeSkipsUpdate(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance(t, "test-pool", "default")
+	scheme := newTestScheme()
+
+	// Build the desired deployment to use as the "existing" one
+	existing := agentPoolDeployment(ap)
+	existing.ResourceVersion = "12345"
+	// Set owner reference as updateDeployment does
+	existing.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         "app.terraform.io/v1alpha2",
+			Kind:               "AgentPool",
+			Name:               ap.instance.Name,
+			UID:                ap.instance.UID,
+			Controller:         pointer.PointerOf(true),
+			BlockOwnerDeletion: pointer.PointerOf(true),
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		Build()
+
+	r := &AgentPoolReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := r.updateDeployment(context.Background(), ap, existing)
+	require.NoError(t, err)
+
+	// Verify the deployment was NOT updated by checking ResourceVersion is unchanged
+	var result appsv1.Deployment
+	err = c.Get(context.Background(), types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &result)
+	require.NoError(t, err)
+	assert.Equal(t, "12345", result.ResourceVersion)
+}
+
+func TestUpdateDeployment_SpecChangeTriggersUpdate(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance(t, "test-pool", "default")
+	scheme := newTestScheme()
+
+	// Build the "existing" deployment with different replicas
+	existing := agentPoolDeployment(ap)
+	existing.ResourceVersion = "12345"
+	existing.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         "app.terraform.io/v1alpha2",
+			Kind:               "AgentPool",
+			Name:               ap.instance.Name,
+			UID:                ap.instance.UID,
+			Controller:         pointer.PointerOf(true),
+			BlockOwnerDeletion: pointer.PointerOf(true),
+		},
+	}
+	// Change replicas on the existing deployment so it differs from desired
+	existing.Spec.Replicas = pointer.PointerOf(int32(1))
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		Build()
+
+	r := &AgentPoolReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := r.updateDeployment(context.Background(), ap, existing)
+	require.NoError(t, err)
+
+	// Verify the deployment was updated — replicas should now be 3
+	var result appsv1.Deployment
+	err = c.Get(context.Background(), types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &result)
+	require.NoError(t, err)
+	assert.Equal(t, pointer.PointerOf(int32(3)), result.Spec.Replicas)
+}
+
+func TestUpdateDeployment_AnnotationChangeTriggersUpdate(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance(t, "test-pool", "default")
+	scheme := newTestScheme()
+
+	// Build the "existing" deployment with different annotations
+	existing := agentPoolDeployment(ap)
+	existing.ResourceVersion = "12345"
+	existing.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         "app.terraform.io/v1alpha2",
+			Kind:               "AgentPool",
+			Name:               ap.instance.Name,
+			UID:                ap.instance.UID,
+			Controller:         pointer.PointerOf(true),
+			BlockOwnerDeletion: pointer.PointerOf(true),
+		},
+	}
+	// Change annotations on the existing deployment
+	existing.Annotations["extra-annotation"] = "old-value"
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		Build()
+
+	r := &AgentPoolReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := r.updateDeployment(context.Background(), ap, existing)
+	require.NoError(t, err)
+
+	// Verify annotations were updated (extra-annotation should be gone)
+	var result appsv1.Deployment
+	err = c.Get(context.Background(), types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &result)
+	require.NoError(t, err)
+	_, hasExtra := result.Annotations["extra-annotation"]
+	assert.False(t, hasExtra, "extra annotation should have been removed by update")
+}
+
+func TestUpdateDeployment_PreservesResourceVersion(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance(t, "test-pool", "default")
+	scheme := newTestScheme()
+
+	existing := agentPoolDeployment(ap)
+	existing.ResourceVersion = "12345"
+	existing.OwnerReferences = []metav1.OwnerReference{
+		{
+			APIVersion:         "app.terraform.io/v1alpha2",
+			Kind:               "AgentPool",
+			Name:               ap.instance.Name,
+			UID:                ap.instance.UID,
+			Controller:         pointer.PointerOf(true),
+			BlockOwnerDeletion: pointer.PointerOf(true),
+		},
+	}
+	// Force a change so the update path is taken
+	existing.Spec.Replicas = pointer.PointerOf(int32(1))
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(existing).
+		Build()
+
+	r := &AgentPoolReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := r.updateDeployment(context.Background(), ap, existing)
+	require.NoError(t, err)
+
+	// The update should succeed because existing has ResourceVersion
+	var result appsv1.Deployment
+	err = c.Get(context.Background(), types.NamespacedName{Name: existing.Name, Namespace: existing.Namespace}, &result)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result.ResourceVersion, "ResourceVersion should be preserved after update")
+}
+
+func TestAgentPoolDeployment_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance(t, "test-pool", "default")
+
+	d1 := agentPoolDeployment(ap)
+	d2 := agentPoolDeployment(ap)
+
+	// Two calls with the same input should produce identical specs
+	assert.True(t, cmp.Equal(d1.Spec, d2.Spec), "agentPoolDeployment should produce deterministic output")
+	assert.True(t, cmp.Equal(d1.Annotations, d2.Annotations), "agentPoolDeployment annotations should be deterministic")
+}
+
+func TestAgentPoolDeployment_DefaultValues(t *testing.T) {
+	t.Parallel()
+
+	ap := newTestAgentPoolInstance(t, "test-pool", "default")
+	ap.instance.Spec.AgentDeployment.Replicas = nil // use default
+
+	d := agentPoolDeployment(ap)
+
+	assert.Equal(t, pointer.PointerOf(int32(1)), d.Spec.Replicas, "should default to 1 replica")
+	assert.Equal(t, &agentTerminationGracePeriod, d.Spec.Template.Spec.TerminationGracePeriodSeconds, "should set 15min termination grace period")
+	assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, d.Spec.Strategy.Type)
+	assert.Equal(t, pointer.PointerOf(intstr.FromInt(0)), d.Spec.Strategy.RollingUpdate.MaxSurge)
 }


### PR DESCRIPTION
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

No changes to security controls

### Description

This PR improves the agent pool deployment reconciliation by implementing smart change detection to avoid unnecessary updates. Previously, the deployment was always updated regardless of whether any changes were made. Now, the controller compares the desired state with the existing deployment and only updates when actual changes are detected.

Two main changes:

1. **Smart Change Detection**: Added comparison logic using `cmp.Equal()` to detect changes in both the deployment spec and annotations before updating
2. **Preserve Server-Managed Fields**: Modified the update approach to apply desired state onto the existing deployment object, preserving the ResourceVersion and other server-managed fields

(Disclosure: this change was created with Claude, but reviewed by me. Happy to try to consolidate the tests if they seem unwieldy or unnecessary, as is sometimes the case...)

### Usage Example

n/a-- it's all behind the scenes!

### References

n/a

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.