### PR TITLE
🐛 Fix issue with spec container env vars getting overridden by defaults

### DIFF
--- a/.changes/unreleased/BUG FIXES-709-20260415-163638.yaml
+++ b/.changes/unreleased/BUG FIXES-709-20260415-163638.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Fix issue with spec container env vars getting overridden by defaults
+time: 2026-04-15T16:36:38.942638-07:00
+custom:
+    PR: "709"

--- a/internal/controller/agentpool_controller_deployment.go
+++ b/internal/controller/agentpool_controller_deployment.go
@@ -196,8 +196,21 @@ func agentPoolDeployment(ap *agentPoolInstance) *appsv1.Deployment {
 }
 
 func decorateDeployment(ap *agentPoolInstance, d *appsv1.Deployment) {
-	envs := []corev1.EnvVar{
-		{
+	// Set TFE_ADDRESS on agent Pod if differnet than default TFC endpoint
+	bURL := ap.tfClient.Client.BaseURL()
+	setCustomTFEAddress := false
+	if defURL, perr := url.Parse(tfc.DefaultAddress); perr == nil && defURL.Host != bURL.Host {
+		setCustomTFEAddress = true
+	}
+
+	// Inject required environment vars into each container, preserving user-supplied values.
+	for ci := range d.Spec.Template.Spec.Containers {
+		envs := d.Spec.Template.Spec.Containers[ci].Env
+		envs = appendEnvVarIfMissing(envs, corev1.EnvVar{
+			Name:  "TFC_AGENT_AUTO_UPDATE",
+			Value: "disabled",
+		})
+		envs = appendEnvVarIfMissing(envs, corev1.EnvVar{
 			Name: "TFC_AGENT_TOKEN",
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
@@ -205,32 +218,41 @@ func decorateDeployment(ap *agentPoolInstance, d *appsv1.Deployment) {
 					Key:                  ap.instance.Status.AgentTokens[0].Name,
 				},
 			},
-		},
-		{
+		})
+		envs = appendEnvVarIfMissing(envs, corev1.EnvVar{
 			Name: "TFC_AGENT_NAME",
 			ValueFrom: &corev1.EnvVarSource{
 				FieldRef: &corev1.ObjectFieldSelector{
 					FieldPath: "metadata.name",
 				},
 			},
-		},
-		{
-			Name:  "TFC_AGENT_AUTO_UPDATE",
-			Value: "disabled",
-		},
-	}
-	// Set TFE_ADDRESS on agent Pod if differnet than default TFC endpoint.
-	bURL := ap.tfClient.Client.BaseURL()
-	if defURL, perr := url.Parse(tfc.DefaultAddress); perr == nil && defURL.Host != bURL.Host {
-		envs = append(envs, corev1.EnvVar{
-			Name:  "TFC_ADDRESS",
-			Value: bURL.String(),
 		})
+		if setCustomTFEAddress {
+			envs = appendEnvVarIfMissing(envs, corev1.EnvVar{
+				Name:  "TFC_ADDRESS",
+				Value: bURL.String(),
+			})
+		}
+
+		d.Spec.Template.Spec.Containers[ci].Env = envs
 	}
-	// Inject agent specific environment vars to each container in the Deployment.
-	for ci := range d.Spec.Template.Spec.Containers {
-		d.Spec.Template.Spec.Containers[ci].Env = append(d.Spec.Template.Spec.Containers[ci].Env, envs...)
+}
+
+func appendEnvVarIfMissing(envs []corev1.EnvVar, env corev1.EnvVar) []corev1.EnvVar {
+	if envVarExists(envs, env.Name) {
+		return envs
 	}
+
+	return append(envs, env)
+}
+
+func envVarExists(envs []corev1.EnvVar, name string) bool {
+	for _, env := range envs {
+		if env.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 func AgentPoolDeploymentName(ap *appv1alpha2.AgentPool) string {

--- a/internal/controller/agentpool_controller_deployment_test.go
+++ b/internal/controller/agentpool_controller_deployment_test.go
@@ -1,0 +1,132 @@
+// Copyright IBM Corp. 2022, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package controller
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	tfc "github.com/hashicorp/go-tfe"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appv1alpha2 "github.com/hashicorp/hcp-terraform-operator/api/v1alpha2"
+)
+
+func TestDecorateDeployment_MixedContainerEnvSets(t *testing.T) {
+	t.Parallel()
+
+	tfServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v2/ping" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer tfServer.Close()
+
+	client, err := tfc.NewClient(&tfc.Config{
+		Address: tfServer.URL,
+		Token:   "test-token",
+	})
+	require.NoError(t, err)
+
+	ap := &agentPoolInstance{
+		instance: appv1alpha2.AgentPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pool-a",
+				Namespace: "default",
+			},
+			Status: appv1alpha2.AgentPoolStatus{
+				AgentTokens: []*appv1alpha2.AgentAPIToken{{Name: "token-a"}},
+			},
+		},
+		tfClient: HCPTerraformClient{Client: client},
+	}
+
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "agent-0",
+							Env: []corev1.EnvVar{
+								{Name: "TFC_AGENT_AUTO_UPDATE", Value: "minor"},
+								{Name: "TFC_ADDRESS", Value: "https://already-set.example.com"},
+							},
+						},
+						{
+							Name: "agent-1",
+							Env: []corev1.EnvVar{
+								{Name: "TFC_AGENT_NAME", Value: "custom-agent-name"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	decorateDeployment(ap, d)
+
+	container0 := d.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, 1, countEnvVar(container0.Env, "TFC_AGENT_AUTO_UPDATE"))
+	assert.Equal(t, "minor", mustFindEnvVar(t, container0.Env, "TFC_AGENT_AUTO_UPDATE").Value)
+	assert.Equal(t, 1, countEnvVar(container0.Env, "TFC_AGENT_TOKEN"))
+	assert.Equal(
+		t,
+		agentPoolOutputObjectName(ap.instance.Name),
+		mustFindEnvVar(t, container0.Env, "TFC_AGENT_TOKEN").ValueFrom.SecretKeyRef.Name,
+	)
+	assert.Equal(t, "token-a", mustFindEnvVar(t, container0.Env, "TFC_AGENT_TOKEN").ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, 1, countEnvVar(container0.Env, "TFC_AGENT_NAME"))
+	assert.Equal(t, "metadata.name", mustFindEnvVar(t, container0.Env, "TFC_AGENT_NAME").ValueFrom.FieldRef.FieldPath)
+	assert.Equal(t, 1, countEnvVar(container0.Env, "TFC_ADDRESS"))
+	assert.Equal(t, "https://already-set.example.com", mustFindEnvVar(t, container0.Env, "TFC_ADDRESS").Value)
+
+	container1 := d.Spec.Template.Spec.Containers[1]
+	customURL := ap.tfClient.Client.BaseURL()
+	assert.Equal(t, 1, countEnvVar(container1.Env, "TFC_AGENT_AUTO_UPDATE"))
+	assert.Equal(t, "disabled", mustFindEnvVar(t, container1.Env, "TFC_AGENT_AUTO_UPDATE").Value)
+	assert.Equal(t, 1, countEnvVar(container1.Env, "TFC_AGENT_TOKEN"))
+	assert.Equal(
+		t,
+		agentPoolOutputObjectName(ap.instance.Name),
+		mustFindEnvVar(t, container1.Env, "TFC_AGENT_TOKEN").ValueFrom.SecretKeyRef.Name,
+	)
+	assert.Equal(t, "token-a", mustFindEnvVar(t, container1.Env, "TFC_AGENT_TOKEN").ValueFrom.SecretKeyRef.Key)
+	assert.Equal(t, 1, countEnvVar(container1.Env, "TFC_AGENT_NAME"))
+	assert.Equal(t, "custom-agent-name", mustFindEnvVar(t, container1.Env, "TFC_AGENT_NAME").Value)
+	assert.Equal(t, 1, countEnvVar(container1.Env, "TFC_ADDRESS"))
+	assert.Equal(t, customURL.String(), mustFindEnvVar(t, container1.Env, "TFC_ADDRESS").Value)
+}
+
+func mustFindEnvVar(t *testing.T, envs []corev1.EnvVar, name string) corev1.EnvVar {
+	t.Helper()
+
+	for _, env := range envs {
+		if env.Name == name {
+			return env
+		}
+	}
+
+	t.Fatalf("env var %q not found", name)
+	return corev1.EnvVar{}
+}
+
+func countEnvVar(envs []corev1.EnvVar, name string) int {
+	count := 0
+	for _, env := range envs {
+		if env.Name == name {
+			count++
+		}
+	}
+
+	return count
+}


### PR DESCRIPTION
<!---
Please DO NOT remove any fields from this template. If there is nothing to add, fill in N/A.
Use emojis in the pull request title according to its type:
 - Bug fix: 🐛 Fix ...
 - New feature or enhancement: 🚀 Add ...
 - Documentation: 📖 ...
 - Dependency update: 🌱 Bump ...
For the rest type of the pull requests please use ✨.

Thank you!
--->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

## Rollback Plan

If a change needs to be reverted, we will publish an updated version of the library.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

<!---
Please describe your changes to security controls in detail.
--->

### Description

When env vars are set in the container spec for AgentPool deployment yamls E.g. https://github.com/hashicorp/hcp-terraform-operator/blob/main/docs/examples/agentPool-deployment.yaml#L20-L23 the agent controller would override the spec env var values with defaults. This happened because the `decorateDeployment` function appended default env vars to the end of the env vars fetched from the spec. https://github.com/hashicorp/hcp-terraform-operator/blob/90b5178ea11defddea8cfc475f416598480a5830/internal/controller/agentpool_controller_deployment.go#L232
Since kubernetes gives precedence to the last set value for an env var the default value is always used and the value set in the spec is disregarded. 
This fix will preserve any env var values set in the spec and use defaults when no spec values are set. It also does not create duplicate env vars in the list. 

Note: Unit test for the function `decorateDeployment` was created using Github Copilot.


### References

<!---
Are there any other GitHub issues (open or closed) or Pull Requests that should be linked here?
For example:
 - Fixes: GH-0000
-->

### Community Note
<!--- Please keep this note for the community --->
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request.
* If you are interested in working on this issue or have submitted a pull request, please leave a comment.
